### PR TITLE
fix(monitoring): send production alerts to Telegram

### DIFF
--- a/monitoring/production/README.md
+++ b/monitoring/production/README.md
@@ -17,8 +17,9 @@ Required configuration:
 - Set `PUBLIC_API_HEALTH_URL=https://<api-domain>/health/ready` and
   `WEB_HEALTH_URL=https://<web-domain>/health` on Prometheus. Startup fails if
   either public end-to-end probe is missing.
-- Set `ALERTMANAGER_SLACK_WEBHOOK_URL` on Alertmanager. The container refuses to
-  start without a real notification destination.
+- Set `ALERTMANAGER_TELEGRAM_BOT_TOKEN` and `ALERTMANAGER_TELEGRAM_CHAT_ID` on
+  Alertmanager. The chat ID may be negative for a Telegram group. The container
+  refuses to start unless both values are present.
 - Set `GF_SECURITY_ADMIN_USER`, `GF_SECURITY_ADMIN_PASSWORD`,
   `GF_USERS_ALLOW_SIGN_UP=false`, `GF_AUTH_ANONYMOUS_ENABLED=false`, and
   `PROMETHEUS_URL=http://prometheus.railway.internal:9090` on Grafana.
@@ -36,4 +37,4 @@ Required configuration:
   health path, rollout overlap, and graceful shutdown window for each service.
 
 After rollout, confirm every target is `UP`, deliberately stop a non-production
-service, and verify that the Slack alert fires and later resolves.
+service, and verify that the Telegram alert fires and later resolves.

--- a/monitoring/production/alertmanager/alertmanager.yml
+++ b/monitoring/production/alertmanager/alertmanager.yml
@@ -12,13 +12,14 @@ route:
 
 receivers:
   - name: operations
-    slack_configs:
-      - api_url_file: /tmp/apsara-slack-webhook
-        channel: '#apsara-operations'
+    telegram_configs:
+      - bot_token_file: /tmp/apsara-telegram-bot-token
+        chat_id_file: /tmp/apsara-telegram-chat-id
         send_resolved: true
-        title: '{{ .CommonLabels.alertname }} ({{ .CommonLabels.severity }})'
-        text: >-
-          {{ range .Alerts }}*{{ .Annotations.summary }}*
+        parse_mode: ''
+        message: >-
+          {{ .CommonLabels.alertname }} ({{ .CommonLabels.severity }})
+          {{ range .Alerts }}{{ .Annotations.summary }}
           {{ .Annotations.description }}
           {{ end }}
 

--- a/monitoring/production/alertmanager/entrypoint.sh
+++ b/monitoring/production/alertmanager/entrypoint.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 set -eu
 
-: "${ALERTMANAGER_SLACK_WEBHOOK_URL:?Configure an operations Slack webhook}"
+: "${ALERTMANAGER_TELEGRAM_BOT_TOKEN:?Configure the Telegram bot token}"
+: "${ALERTMANAGER_TELEGRAM_CHAT_ID:?Configure the Telegram destination chat ID}"
 umask 077
-printf '%s' "$ALERTMANAGER_SLACK_WEBHOOK_URL" > /tmp/apsara-slack-webhook
+printf '%s' "$ALERTMANAGER_TELEGRAM_BOT_TOKEN" > /tmp/apsara-telegram-bot-token
+printf '%s' "$ALERTMANAGER_TELEGRAM_CHAT_ID" > /tmp/apsara-telegram-chat-id
 
 exec /bin/alertmanager \
   --config.file=/etc/alertmanager/alertmanager.yml \


### PR DESCRIPTION
## Summary
- replace the production Slack receiver with Telegram
- read the bot token and group chat ID from protected files created at startup
- document the two required Railway variables and Telegram verification flow

## Validation
- shell syntax check
- YAML parse check
- git diff check
- GitHub CI validates the Alertmanager configuration and builds the production monitoring image