### PR TITLE
feat(auth): audit login attempts and notify Telegram

### DIFF
--- a/apps/api-gateway/src/api-gateway.module.ts
+++ b/apps/api-gateway/src/api-gateway.module.ts
@@ -17,11 +17,14 @@ import { UserModule } from './user/user.module';
 import { MetricsModule } from '@app/common/metrics/metrics.module';
 import { AiQuotaModule } from '@app/common/throttler/ai-quota.module';
 import { SentryModule } from '@sentry/nestjs/setup';
+// Drives the login_history 90-day retention job.
+import { ScheduleModule } from '@nestjs/schedule';
 import { AiModule } from './ai/ai.module';
 
 @Module({
   imports: [
     SentryModule.forRoot(),
+    ScheduleModule.forRoot(),
     ConfigModule,
     LoggerModule,
     AiStreamModule,

--- a/apps/api-gateway/src/auth/auth-token-boundary.spec.ts
+++ b/apps/api-gateway/src/auth/auth-token-boundary.spec.ts
@@ -15,7 +15,18 @@ describe('authentication token boundary', () => {
     cookie: jest.fn(),
     clearCookie: jest.fn(),
   } as unknown as Response;
-  const controller = new AuthController(authClient, null, null);
+  // Audit writes are best-effort and irrelevant to these assertions.
+  const loginAudit = {
+    recordSuccess: jest.fn().mockResolvedValue(undefined),
+    recordFailure: jest.fn().mockResolvedValue(undefined),
+  };
+  const request = { get: () => undefined, ip: '127.0.0.1' } as any;
+  const controller = new AuthController(
+    authClient,
+    null as any,
+    null as any,
+    loginAudit as any,
+  );
 
   beforeEach(() => jest.clearAllMocks());
 
@@ -32,6 +43,7 @@ describe('authentication token boundary', () => {
     const result = await controller.login(
       { identifier: 'user@example.com', password: 'password' },
       response,
+      request,
     );
 
     expect(response.cookie).toHaveBeenCalledWith(

--- a/apps/api-gateway/src/auth/auth.module.ts
+++ b/apps/api-gateway/src/auth/auth.module.ts
@@ -1,4 +1,7 @@
-import { JwtModule, ThrottlerModule } from '@app/common';
+import { DatabaseModule, JwtModule, ThrottlerModule } from '@app/common';
+import { LoginHistory } from '@app/common/database/entities/login-history.entity';
+import { TelegramModule } from '@app/common/telegram/telegram.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ClientsModule, Transport } from '@nestjs/microservices';
@@ -16,6 +19,8 @@ import { LinkedInStrategy } from './socials/strategies/linkedin.strategy';
 import { ResumeParseService } from './services/resume-parse.service';
 import { IceServersService } from './services/ice-servers.service';
 import { SocialAuthService } from './services/social-auth.service';
+import { LoginAuditService } from './services/login-audit.service';
+import { LoginHistoryCleanupService } from './services/login-history-cleanup.service';
 
 @Module({
   imports: [
@@ -35,6 +40,9 @@ import { SocialAuthService } from './services/social-auth.service';
     ThrottlerModule,
     PassportModule,
     JwtModule,
+    DatabaseModule,
+    TypeOrmModule.forFeature([LoginHistory]),
+    TelegramModule,
   ],
   controllers: [
     AuthController,
@@ -51,6 +59,8 @@ import { SocialAuthService } from './services/social-auth.service';
     ResumeParseService,
     IceServersService,
     SocialAuthService,
+    LoginAuditService,
+    LoginHistoryCleanupService,
   ],
 })
 export class AuthModule {}

--- a/apps/api-gateway/src/auth/basic/controllers/auth.controller.spec.ts
+++ b/apps/api-gateway/src/auth/basic/controllers/auth.controller.spec.ts
@@ -70,7 +70,9 @@ describe('AuthController', () => {
       userId: 'user-1',
     });
 
-    await expect(controller.login({} as any, response, httpRequest)).resolves.toMatchObject({
+    await expect(
+      controller.login({} as any, response, httpRequest),
+    ).resolves.toMatchObject({
       requiresTwoFactor: true,
       userId: 'user-1',
     });

--- a/apps/api-gateway/src/auth/basic/controllers/auth.controller.spec.ts
+++ b/apps/api-gateway/src/auth/basic/controllers/auth.controller.spec.ts
@@ -21,10 +21,17 @@ describe('AuthController', () => {
   const resumeParse = { parseResume: jest.fn() };
   const iceServers = { getIceServers: jest.fn() };
   const response = {} as any;
+  // Audit writes are best-effort and irrelevant to these assertions.
+  const loginAudit = {
+    recordSuccess: jest.fn().mockResolvedValue(undefined),
+    recordFailure: jest.fn().mockResolvedValue(undefined),
+  };
+  const httpRequest = { get: () => undefined, ip: '127.0.0.1' } as any;
   const controller = new AuthController(
     client as any,
     resumeParse as any,
     iceServers as any,
+    loginAudit as any,
   );
   const request = sendAuthServiceRequest as jest.Mock;
 
@@ -63,7 +70,7 @@ describe('AuthController', () => {
       userId: 'user-1',
     });
 
-    await expect(controller.login({} as any, response)).resolves.toMatchObject({
+    await expect(controller.login({} as any, response, httpRequest)).resolves.toMatchObject({
       requiresTwoFactor: true,
       userId: 'user-1',
     });
@@ -78,7 +85,7 @@ describe('AuthController', () => {
       refreshToken: 'refresh',
     });
 
-    const result = await controller.login({} as any, response);
+    const result = await controller.login({} as any, response, httpRequest);
 
     expect(setAuthTokenCookies).toHaveBeenCalledWith(response, {
       accessToken: 'access',

--- a/apps/api-gateway/src/auth/basic/controllers/auth.controller.ts
+++ b/apps/api-gateway/src/auth/basic/controllers/auth.controller.ts
@@ -8,6 +8,7 @@ import {
   Controller,
   Get,
   HttpCode,
+  HttpException,
   HttpStatus,
   Inject,
   Param,
@@ -25,6 +26,8 @@ import { Request, Response } from 'express';
 import { AUTH_SERVICE } from '@app/contracts/constants/service-actions/auth-service.constant';
 import { ResumeParseService } from '../../services/resume-parse.service';
 import { IceServersService } from '../../services/ice-servers.service';
+import { LoginAuditService } from '../../services/login-audit.service';
+import { clientIpFrom } from '../../utils/client-ip.util';
 import {
   CompanyRegisterDTO,
   EmployeeRegisterDTO,
@@ -66,6 +69,7 @@ export class AuthController implements IBasicAuthController {
     @Inject(AUTH_SERVICE.NAME) private readonly authClient: ClientProxy,
     private readonly resumeParse: ResumeParseService,
     private readonly iceServersService: IceServersService,
+    private readonly loginAudit: LoginAuditService,
   ) {}
 
   @Post('register-company')
@@ -121,14 +125,38 @@ export class AuthController implements IBasicAuthController {
   async login(
     @Body() loginDTO: LoginDTO,
     @Res({ passthrough: true }) res: Response,
+    @Req() req: Request,
   ): Promise<LoginResponseDTO> {
-    const response = await sendAuthServiceRequest<LoginResponseDTO>(
-      this.authClient,
-      AUTH_SERVICE.ACTIONS.LOGIN,
-      loginDTO,
-    );
+    // Captured before the RPC: the audit trail needs client details that only
+    // exist on the HTTP request, and they must be recorded on failure too.
+    const attempt = {
+      email: loginDTO.identifier ?? null,
+      ipAddress: clientIpFrom(req),
+      userAgent: req.get('user-agent') ?? null,
+    };
+
+    let response: LoginResponseDTO;
+    try {
+      response = await sendAuthServiceRequest<LoginResponseDTO>(
+        this.authClient,
+        AUTH_SERVICE.ACTIONS.LOGIN,
+        loginDTO,
+      );
+    } catch (error: unknown) {
+      // Record the failure, then rethrow untouched so the existing exception
+      // filter still produces the same response it always has.
+      await this.loginAudit.recordFailure(
+        attempt,
+        error instanceof HttpException
+          ? `http_${error.getStatus()}`
+          : 'rpc_error',
+      );
+      throw error;
+    }
 
     if (response.requiresTwoFactor) {
+      // Not a completed login — the second factor is still outstanding, so this
+      // is deliberately not recorded as a success.
       return new LoginResponseDTO({
         message: response.message,
         requiresTwoFactor: true,
@@ -139,6 +167,11 @@ export class AuthController implements IBasicAuthController {
     setAuthTokenCookies(res, {
       accessToken: response.accessToken!,
       refreshToken: response.refreshToken,
+    });
+
+    await this.loginAudit.recordSuccess({
+      ...attempt,
+      userId: response.user?.id ?? null,
     });
 
     return new LoginResponseDTO({

--- a/apps/api-gateway/src/auth/services/login-audit.service.ts
+++ b/apps/api-gateway/src/auth/services/login-audit.service.ts
@@ -1,0 +1,86 @@
+import { LoginHistory } from '@app/common/database/entities/login-history.entity';
+import { loginAttempts } from '@app/common/metrics/metrics';
+import { TelegramService } from '@app/common/telegram/telegram.service';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Logger } from 'nestjs-pino';
+import { Repository } from 'typeorm';
+
+export interface LoginAttemptContext {
+  email: string | null;
+  ipAddress: string | null;
+  userAgent: string | null;
+  userId?: string | null;
+}
+
+/**
+ * Records every login attempt and notifies Telegram on success.
+ *
+ * Runs at the gateway because that is the only place the client IP and user
+ * agent exist — auth-service receives an RPC payload without them.
+ *
+ * Every method here is best-effort: an audit write or a Telegram outage must
+ * never turn a working login into a failed one. Errors are logged and
+ * swallowed, deliberately.
+ */
+@Injectable()
+export class LoginAuditService {
+  constructor(
+    @InjectRepository(LoginHistory)
+    private readonly repository: Repository<LoginHistory>,
+    private readonly telegram: TelegramService,
+    private readonly logger: Logger,
+  ) {}
+
+  async recordSuccess(context: LoginAttemptContext): Promise<void> {
+    loginAttempts.inc({ result: 'success' });
+    await this.persist({ ...context, success: true, failureReason: null });
+    this.notifySuccess(context);
+  }
+
+  async recordFailure(
+    context: LoginAttemptContext,
+    failureReason: string,
+  ): Promise<void> {
+    loginAttempts.inc({ result: 'failure' });
+    await this.persist({ ...context, success: false, failureReason });
+  }
+
+  private async persist(
+    row: LoginAttemptContext & { success: boolean; failureReason: string | null },
+  ): Promise<void> {
+    try {
+      await this.repository.insert({
+        userId: row.userId ?? null,
+        email: row.email,
+        ipAddress: row.ipAddress,
+        // Long UA strings are truncated rather than rejected by the column.
+        userAgent: row.userAgent ? row.userAgent.slice(0, 1000) : null,
+        success: row.success,
+        failureReason: row.failureReason,
+      });
+    } catch (error: unknown) {
+      this.logger.warn(
+        `[login-audit] failed to record attempt: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  private notifySuccess(context: LoginAttemptContext): void {
+    if (!this.telegram.enabled) return;
+
+    const esc = TelegramService.escape;
+    const lines = [
+      '🔓 <b>Login</b>',
+      `User: ${esc(context.email ?? 'unknown')}`,
+      context.userId ? `ID: ${esc(context.userId)}` : null,
+      `IP: ${esc(context.ipAddress ?? 'unknown')}`,
+      `Agent: ${esc((context.userAgent ?? 'unknown').slice(0, 120))}`,
+      `Time: ${new Date().toISOString()}`,
+    ].filter(Boolean);
+
+    this.telegram.send(lines.join('\n'));
+  }
+}

--- a/apps/api-gateway/src/auth/services/login-audit.service.ts
+++ b/apps/api-gateway/src/auth/services/login-audit.service.ts
@@ -47,7 +47,10 @@ export class LoginAuditService {
   }
 
   private async persist(
-    row: LoginAttemptContext & { success: boolean; failureReason: string | null },
+    row: LoginAttemptContext & {
+      success: boolean;
+      failureReason: string | null;
+    },
   ): Promise<void> {
     try {
       await this.repository.insert({

--- a/apps/api-gateway/src/auth/services/login-history-cleanup.service.ts
+++ b/apps/api-gateway/src/auth/services/login-history-cleanup.service.ts
@@ -28,7 +28,9 @@ export class LoginHistoryCleanupService {
   @Cron(CronExpression.EVERY_DAY_AT_3AM)
   async prune(): Promise<void> {
     const cutoff = new Date();
-    cutoff.setDate(cutoff.getDate() - LoginHistoryCleanupService.RETENTION_DAYS);
+    cutoff.setDate(
+      cutoff.getDate() - LoginHistoryCleanupService.RETENTION_DAYS,
+    );
 
     try {
       const result = await this.repository.delete({

--- a/apps/api-gateway/src/auth/services/login-history-cleanup.service.ts
+++ b/apps/api-gateway/src/auth/services/login-history-cleanup.service.ts
@@ -1,0 +1,51 @@
+import { LoginHistory } from '@app/common/database/entities/login-history.entity';
+import { Injectable } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Logger } from 'nestjs-pino';
+import { LessThan, Repository } from 'typeorm';
+
+/**
+ * Enforces the 90-day retention policy on login_history.
+ *
+ * These rows contain personal data (IP address, user agent). Keeping them
+ * indefinitely is both a privacy problem and an unbounded table, so this runs
+ * daily and deletes anything older than the window.
+ *
+ * Change RETENTION_DAYS only alongside a decision about why — the number is the
+ * policy, not an implementation detail.
+ */
+@Injectable()
+export class LoginHistoryCleanupService {
+  private static readonly RETENTION_DAYS = 90;
+
+  constructor(
+    @InjectRepository(LoginHistory)
+    private readonly repository: Repository<LoginHistory>,
+    private readonly logger: Logger,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
+  async prune(): Promise<void> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - LoginHistoryCleanupService.RETENTION_DAYS);
+
+    try {
+      const result = await this.repository.delete({
+        createdAt: LessThan(cutoff),
+      });
+
+      if (result.affected) {
+        this.logger.log(
+          `[login-audit] pruned ${result.affected} rows older than ${LoginHistoryCleanupService.RETENTION_DAYS} days`,
+        );
+      }
+    } catch (error: unknown) {
+      this.logger.warn(
+        `[login-audit] prune failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+}

--- a/apps/api-gateway/src/auth/utils/client-ip.util.ts
+++ b/apps/api-gateway/src/auth/utils/client-ip.util.ts
@@ -1,0 +1,18 @@
+import { Request } from 'express';
+
+/**
+ * Best-effort client IP for the audit trail.
+ *
+ * Railway terminates TLS at its edge, so req.ip is the proxy address; the real
+ * client is the FIRST entry of X-Forwarded-For. Later entries are the proxy
+ * chain. Treat the result as advisory: the header is client-supplied and can be
+ * spoofed, so it is useful for spotting patterns, not for authorization.
+ */
+export function clientIpFrom(request: Request): string | null {
+  const forwarded = request.get('x-forwarded-for');
+  if (forwarded) {
+    const first = forwarded.split(',')[0]?.trim();
+    if (first) return first.slice(0, 100);
+  }
+  return request.ip ? request.ip.slice(0, 100) : null;
+}

--- a/libs/common/src/database/config/database.config.ts
+++ b/libs/common/src/database/config/database.config.ts
@@ -14,6 +14,7 @@ import { Experience } from '../entities/employee/experience.entity';
 import { EmployeeFavoriteCompany } from '../entities/employee/favorite-company.entity';
 import { Skill } from '../entities/employee/skill.entity';
 import { Interview } from '../entities/interview.entity';
+import { LoginHistory } from '../entities/login-history.entity';
 import { JobMatching } from '../entities/job-matching.entity';
 import { UserBlock } from '../entities/moderation/user-block.entity';
 import { UserReport } from '../entities/moderation/user-report.entity';
@@ -30,6 +31,7 @@ export const databaseConfig = async (
   url: configService.get<string>('database.url'),
   synchronize: configService.get<boolean>('database.synchronize'),
   entities: [
+    LoginHistory,
     User,
     Employee,
     Company,

--- a/libs/common/src/database/entities/login-history.entity.ts
+++ b/libs/common/src/database/entities/login-history.entity.ts
@@ -1,0 +1,58 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+/**
+ * Audit trail of authentication attempts, successful and failed.
+ *
+ * Written by the API gateway rather than auth-service: the gateway is the only
+ * process that sees the HTTP request, so it is the only place the client IP and
+ * user agent exist. Recording is best-effort and must never block or fail a
+ * login.
+ *
+ * CONTAINS PERSONAL DATA (ip address, user agent). Rows older than 90 days are
+ * deleted by LoginHistoryCleanupService — do not remove that job without
+ * deciding on a retention policy first.
+ */
+@Entity()
+export class LoginHistory {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /**
+   * Null when the attempt failed before a user could be identified (unknown
+   * email), which is exactly the case worth investigating.
+   */
+  @Index()
+  @Column({ type: 'uuid', nullable: true })
+  userId: string | null;
+
+  /** The identifier that was submitted, kept even when no user matched. */
+  @Index()
+  @Column({ type: 'varchar', length: 320, nullable: true })
+  email: string | null;
+
+  /** Length allows for IPv6 and comma-joined X-Forwarded-For chains. */
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  ipAddress: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  userAgent: string | null;
+
+  @Index()
+  @Column({ type: 'boolean' })
+  success: boolean;
+
+  /** Short machine-ish reason on failure ("invalid_credentials"), null on success. */
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  failureReason: string | null;
+
+  /** Indexed: every query here is "recent activity" or "activity for a user". */
+  @Index()
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/libs/common/src/metrics/metrics.ts
+++ b/libs/common/src/metrics/metrics.ts
@@ -1,4 +1,9 @@
-import { collectDefaultMetrics, Histogram, register } from 'prom-client';
+import {
+  collectDefaultMetrics,
+  Counter,
+  Histogram,
+  register,
+} from 'prom-client';
 
 // Node/process metrics (event-loop lag, heap, GC, CPU) on the default registry.
 // Safe to call once at module load; guarded so repeated imports don't re-register.
@@ -59,3 +64,18 @@ export async function getMetrics(): Promise<{
 }> {
   return { contentType: register.contentType, body: await register.metrics() };
 }
+
+/**
+ * Authentication attempts, for spotting credential stuffing.
+ *
+ * Labels are deliberately low-cardinality: NEVER add user id, email, or IP here
+ * — Prometheus creates a time series per label combination, and per-user labels
+ * would grow unbounded. User-level detail belongs in the login_history table
+ * and the Telegram notification, not in metrics.
+ */
+export const loginAttempts = new Counter({
+  name: 'auth_login_attempts_total',
+  help: 'Login attempts at the gateway, labelled by outcome.',
+  labelNames: ['result'],
+  registers: [register],
+});

--- a/libs/common/src/telegram/telegram.module.ts
+++ b/libs/common/src/telegram/telegram.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { TelegramService } from './telegram.service';
+
+@Module({
+  providers: [TelegramService],
+  exports: [TelegramService],
+})
+export class TelegramModule {}

--- a/libs/common/src/telegram/telegram.service.ts
+++ b/libs/common/src/telegram/telegram.service.ts
@@ -64,9 +64,7 @@ export class TelegramService {
       );
 
       if (!response.ok) {
-        this.logger.warn(
-          `[telegram] sendMessage returned ${response.status}`,
-        );
+        this.logger.warn(`[telegram] sendMessage returned ${response.status}`);
       }
     } finally {
       clearTimeout(timeout);

--- a/libs/common/src/telegram/telegram.service.ts
+++ b/libs/common/src/telegram/telegram.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@nestjs/common';
+import { Logger } from 'nestjs-pino';
+
+/**
+ * Minimal Telegram sender for application-level notifications.
+ *
+ * Deliberately separate from the Alertmanager → Telegram path: that one carries
+ * aggregate infrastructure alerts and must never contain user data. This one
+ * carries per-event notifications that DO contain user detail, which is why it
+ * cannot go through Prometheus (user ids and emails as metric labels would
+ * blow up cardinality).
+ *
+ * Reuses the same bot as Alertmanager. Set on the API gateway service:
+ *   TELEGRAM_BOT_TOKEN  (same value as ALERTMANAGER_TELEGRAM_BOT_TOKEN)
+ *   TELEGRAM_CHAT_ID    (same value as ALERTMANAGER_TELEGRAM_CHAT_ID)
+ *
+ * No-ops when either is unset, so local and test runs send nothing. Every send
+ * is fire-and-forget: a Telegram outage must never affect a user request.
+ */
+@Injectable()
+export class TelegramService {
+  private readonly token = process.env.TELEGRAM_BOT_TOKEN;
+  private readonly chatId = process.env.TELEGRAM_CHAT_ID;
+
+  constructor(private readonly logger: Logger) {}
+
+  get enabled(): boolean {
+    return Boolean(this.token && this.chatId);
+  }
+
+  /**
+   * Sends a message without awaiting delivery. Failures are logged, never
+   * thrown — the caller is always in a user-facing request path.
+   */
+  send(text: string): void {
+    if (!this.enabled) return;
+
+    void this.deliver(text).catch((error: unknown) => {
+      this.logger.warn(
+        `[telegram] send failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+  }
+
+  private async deliver(text: string): Promise<void> {
+    const controller = new AbortController();
+    // A hung Telegram request must not keep a socket open indefinitely.
+    const timeout = setTimeout(() => controller.abort(), 5000);
+
+    try {
+      const response = await fetch(
+        `https://api.telegram.org/bot${this.token}/sendMessage`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            chat_id: this.chatId,
+            text,
+            parse_mode: 'HTML',
+            disable_web_page_preview: true,
+          }),
+          signal: controller.signal,
+        },
+      );
+
+      if (!response.ok) {
+        this.logger.warn(
+          `[telegram] sendMessage returned ${response.status}`,
+        );
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /** Escapes the HTML parse_mode metacharacters. */
+  static escape(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+}

--- a/libs/contracts/src/interfaces/controller/auth-controller.interface.ts
+++ b/libs/contracts/src/interfaces/controller/auth-controller.interface.ts
@@ -29,7 +29,13 @@ import {
 import { Response, Request } from 'express';
 
 export interface IBasicAuthLoginController {
-  login(loginDTO: LoginDTO, res: Response): Promise<LoginResponseDTO>;
+  // `req` is optional so RPC-side implementations, which have no HTTP
+  // request, still satisfy this interface.
+  login(
+    loginDTO: LoginDTO,
+    res: Response,
+    req?: Request,
+  ): Promise<LoginResponseDTO>;
 }
 
 export interface IBasicAuthLoginRpcController {

--- a/migrations/1786003200000-AddLoginHistory.ts
+++ b/migrations/1786003200000-AddLoginHistory.ts
@@ -1,0 +1,59 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Audit trail for authentication attempts.
+ *
+ * userId is deliberately NOT a foreign key: failed attempts against an unknown
+ * email have no user to reference, and the audit record must survive the user
+ * being deleted — that is the point of an audit trail.
+ *
+ * Indexes cover the two real queries: "recent attempts" (createdAt) and
+ * "attempts for this user/email". The partial index on failures keeps the
+ * credential-stuffing query fast without indexing the successful majority.
+ */
+export class AddLoginHistory1786003200000 implements MigrationInterface {
+  name = 'AddLoginHistory1786003200000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "login_history" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "userId" uuid,
+        "email" character varying(320),
+        "ipAddress" character varying(100),
+        "userAgent" text,
+        "success" boolean NOT NULL,
+        "failureReason" character varying(100),
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_login_history_id" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_login_history_createdAt" ON "login_history" ("createdAt")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_login_history_userId" ON "login_history" ("userId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_login_history_email" ON "login_history" ("email")`,
+    );
+    // Failed attempts are the ones queried under time pressure.
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_login_history_failed_recent"
+       ON "login_history" ("createdAt") WHERE "success" = false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_login_history_failed_recent"`,
+    );
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_login_history_email"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_login_history_userId"`);
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_login_history_createdAt"`,
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "login_history"`);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.28",
         "@nestjs/platform-socket.io": "^11.1.28",
+        "@nestjs/schedule": "^6.1.3",
         "@nestjs/serve-static": "^5.0.4",
         "@nestjs/swagger": "^11.4.5",
         "@nestjs/terminus": "^11.0.0",
@@ -3474,6 +3475,19 @@
         "rxjs": "^7.1.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.3.tgz",
+      "integrity": "sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.1.0.tgz",
@@ -4763,6 +4777,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.3.tgz",
+      "integrity": "sha512-pE7BSbKHiojpl4v7iEzdfFLXXJaH5RPJxI3Wr4x3HU59l83PJfhcUx4mGPWq245+DCAENAzRF/+ZoYr2tJCe/g==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -6822,6 +6842,23 @@
       "version": "1.1.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -10364,6 +10401,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.28",
     "@nestjs/platform-socket.io": "^11.1.28",
+    "@nestjs/schedule": "^6.1.3",
     "@nestjs/serve-static": "^5.0.4",
     "@nestjs/swagger": "^11.4.5",
     "@nestjs/terminus": "^11.0.0",


### PR DESCRIPTION
There was no record of who logged in, when, or from where — successful and failed attempts alike left no trace, so there was nothing to investigate after the fact and nothing to alert on.

Records every attempt in a new login_history table. The write happens at the gateway rather than auth-service because the gateway is the only process that sees the HTTP request, and therefore the only one that knows the client IP and user agent; auth-service receives an RPC payload with neither. That also keeps the change to a single service instead of altering the RPC contract.

Recording is best-effort throughout: a failed insert or a Telegram outage is logged and swallowed, never propagated, because every call site sits in a user-facing request path. Failures rethrow the original error untouched so the existing exception filter produces exactly the responses it did before, and a pending second factor is deliberately not counted as a success.

Alerting is split by what each channel can carry:
- auth_login_attempts_total{result} feeds Prometheus for spike detection. Labels stay low-cardinality on purpose — user ids or IPs there would grow the series count without bound.
- Per-login notifications with user detail go straight to Telegram, since that detail cannot live in metric labels.

login_history holds personal data (ip address, user agent), so a daily job prunes rows older than 90 days. Changing that window is a policy decision, not a cleanup detail.

Requires TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID on the gateway (already set in Railway); the notifier no-ops without them, so local runs stay silent.