### PR TITLE
feat(monitoring): alert on login failure spikes

### DIFF
--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -145,3 +145,36 @@ groups:
         annotations:
           summary: 'DB pool near limit in {{ $labels.service }}'
           description: '{{ $labels.service }} is using >90% of its pg pool for 10 minutes (current: {{ $value | humanizePercentage }}).'
+
+  - name: apsaratalent-auth
+    rules:
+      # Credential stuffing signal. StrictThrottle allows 5 attempts per window
+      # per client, so sustained failures above this threshold mean either many
+      # source addresses or a client cycling through windows — neither is a user
+      # who forgot their password.
+      #
+      # Deliberately no user/IP labels: those live in the login_history table and
+      # the Telegram notification. Putting them here would grow the series count
+      # without bound.
+      - alert: LoginFailureSpike
+        expr: increase(auth_login_attempts_total{result="failure"}[5m]) > 10
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Elevated failed logins on {{ $labels.service }}'
+          description: '{{ $value | printf "%.0f" }} failed login attempts in 5 minutes — possible credential stuffing. Check login_history for the source addresses.'
+
+      # A total absence of successful logins while failures continue suggests
+      # authentication is broken rather than under attack.
+      - alert: LoginSuccessStalled
+        expr: |
+          increase(auth_login_attempts_total{result="failure"}[15m]) > 5
+            and
+          increase(auth_login_attempts_total{result="success"}[15m]) == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Logins failing with no successes'
+          description: 'No successful login in 15 minutes while failures continue — authentication may be broken, not merely under attack.'


### PR DESCRIPTION
Acts on the `auth_login_attempts_total` counter that has been emitting since the login audit landed.

**LoginFailureSpike** — more than 10 failures in 5 minutes. StrictThrottle caps a single client at 5 attempts per window, so sustained failures past that mean many source addresses or a client cycling windows.

**LoginSuccessStalled** — failures continuing while successes sit at zero. Looks identical to an attack, but usually means authentication is broken.

Neither rule carries user or IP labels: Prometheus creates a series per label combination, so per-user labels grow unbounded. That detail lives in `login_history` and the Telegram notification instead.

Alerts route through the existing Alertmanager → Telegram pipeline. `monitoring/alerts.yml` is copied into the Prometheus image at build time, so this takes effect when the prometheus service redeploys.

Validated with `promtool check rules`: 15 rules found, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)