### PR TITLE
Stop a network blip from ending a release half-deployed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -510,37 +510,37 @@ jobs:
       # a service does not become active. These are the service names shown in
       # Railway Architecture; GitHub prefixes deployment labels separately.
       - name: Deploy auth service
-        run: railway up --service "Auth Service"
+        run: scripts/ci/railway-up.sh "Auth Service"
 
       - name: Deploy user service
-        run: railway up --service "User Service"
+        run: scripts/ci/railway-up.sh "User Service"
 
       - name: Deploy resume builder service
-        run: railway up --service "Resume Builder Service"
+        run: scripts/ci/railway-up.sh "Resume Builder Service"
 
       - name: Deploy chat service
-        run: railway up --service "Chat Service"
+        run: scripts/ci/railway-up.sh "Chat Service"
 
       - name: Deploy job service
-        run: railway up --service "Job Service"
+        run: scripts/ci/railway-up.sh "Job Service"
 
       - name: Deploy notification service
-        run: railway up --service "Notification Service"
+        run: scripts/ci/railway-up.sh "Notification Service"
 
       - name: Deploy Alertmanager
-        run: railway up --service alertmanager
+        run: scripts/ci/railway-up.sh alertmanager
 
       - name: Deploy blackbox exporter
-        run: railway up --service blackbox-exporter
+        run: scripts/ci/railway-up.sh blackbox-exporter
 
       - name: Deploy Prometheus
-        run: railway up --service prometheus
+        run: scripts/ci/railway-up.sh prometheus
 
       - name: Deploy Grafana
-        run: railway up --service grafana
+        run: scripts/ci/railway-up.sh grafana
 
       - name: Deploy API gateway
-        run: railway up --service "API Gateway"
+        run: scripts/ci/railway-up.sh "API Gateway"
 
       # EXPECTED_RELEASE makes this prove the NEW revision is serving. Without
       # it, a `railway up` that silently changed nothing left the previous
@@ -548,6 +548,18 @@ jobs:
       - name: Verify production liveness and every readiness dependency
         env:
           EXPECTED_RELEASE: ${{ github.sha }}
+        run: node scripts/ci/verify-deployment.mjs "$PRODUCTION_API_URL"
+
+      # A failure part-way through the sequence leaves production on MIXED
+      # revisions and skips the verification above entirely, so without this the
+      # job ends without ever saying what is actually serving. Never gates:
+      # EXPECTED_RELEASE is deliberately unset so this reports rather than
+      # asserts, and continue-on-error keeps it from masking the real failure.
+      - name: Report what production is actually serving
+        if: failure()
+        continue-on-error: true
+        env:
+          DEPLOY_VERIFY_TIMEOUT_MS: "30000"
         run: node scripts/ci/verify-deployment.mjs "$PRODUCTION_API_URL"
 
       # Railway rollback is deliberately not automated here. Rolling back one
@@ -559,10 +571,22 @@ jobs:
         shell: bash
         run: |
           {
-            echo "### ❌ Production verification failed — the new revision is live and unhealthy"
+            echo "### ❌ Release did not complete"
             echo ""
-            echo "Roll back **all** API services together, or none. Mixed revisions"
-            echo "talking over TCP RPC is a second outage."
+            echo "Two different situations end up here — check which one above:"
+            echo ""
+            echo "**A deploy step failed part-way.** Production is on MIXED revisions:"
+            echo "the services listed before the failure are on this release, the rest"
+            echo "are on the previous one. The step above reports what the gateway is"
+            echo "actually serving. If the failure was a Railway transport error, the"
+            echo "wrapper already retried three times — re-running the job is safe and"
+            echo "is usually the fastest fix, because \`railway up\` is idempotent."
+            echo ""
+            echo "**Verification failed after all services deployed.** The new revision"
+            echo "is live and unhealthy."
+            echo ""
+            echo "Either way, roll back **all** API services together, or none. Mixed"
+            echo "revisions talking over TCP RPC is a second outage."
             echo ""
             echo "1. Run the **Roll back Railway services** workflow with"
             echo "   \`service: all\` — it targets the deployment before this one."
@@ -570,4 +594,4 @@ jobs:
             echo "   read docs/RUNBOOK.md §5 *before* reverting it."
             echo "3. Restore point for this release is recorded in the \`migrate\` job summary."
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "::error::Production verification failed. Roll back via the 'Roll back Railway services' workflow (service: all)."
+          echo "::error::Release did not complete. See the job summary — production may be on mixed revisions."

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -219,6 +219,24 @@ are rolling back all API services or one.
 The dashboard path still works if the workflow itself is broken: Railway
 service → **Deployments** → last known-good → **Redeploy**.
 
+#### A deploy that stopped part-way is not automatically a rollback
+
+A release is eleven sequential `railway up` calls. If one fails, the job stops
+there: the services before it are on the new revision, the rest are on the old
+one, and the verification step never runs. The failure summary reports what the
+gateway is actually serving so you are not guessing.
+
+**Re-running the failed job is usually the right move, not rolling back.**
+`railway up` is idempotent, so a re-run simply finishes the sequence. Reach for
+rollback only when the new revision is the problem — not when the deploy was
+merely interrupted.
+
+`scripts/ci/railway-up.sh` already retries transport failures three times with
+backoff (a Railway API timeout aborted a release this way on 2026-08-07). A
+step that fails *after* those retries is either a genuine build failure — the
+wrapper says so explicitly and does not retry — or Railway itself is degraded;
+check <https://status.railway.com> before re-running.
+
 `restartPolicyType = "ON_FAILURE"` with 10 retries means a service
 crash-looping on bad config will retry and then stay down. The checked-in
 Railway configs also allow a 20-second rollout overlap and a 30-second graceful

--- a/scripts/ci/railway-up.sh
+++ b/scripts/ci/railway-up.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Deploy one Railway service, retrying only when the failure looks like the
+# network rather than the build.
+#
+# A release is eleven sequential `railway up` calls. Before this wrapper, any
+# one of them failing ended the release wherever it happened to be: on
+# 2026-08-07 a Railway API timeout ("reqwest error / operation timed out")
+# aborted after four of seven application services, leaving the gateway on the
+# previous revision and skipping verification entirely. The deploy itself was
+# fine — the same step succeeded on retry with no changes.
+#
+# That is the failure mode worth engineering against, because it produces mixed
+# revisions unattended, and mixed revisions over TCP RPC are their own outage
+# (docs/RUNBOOK.md §4).
+#
+# Retries are deliberately NOT blanket. A failed build fails the same way three
+# times; retrying it just burns ten minutes and buries the real error. Only
+# transport-shaped failures are retried.
+#
+# Usage:  scripts/ci/railway-up.sh "Auth Service"
+# Env:    RAILWAY_UP_ATTEMPTS (default 3)
+
+set -uo pipefail
+
+service="${1:?usage: railway-up.sh <service name>}"
+attempts="${RAILWAY_UP_ATTEMPTS:-3}"
+
+# Transport failures: the request never reached Railway, or the stream to it
+# died. None of these say anything about whether the code builds.
+TRANSIENT='operation timed out|reqwest error|error sending request|connection (reset|refused|closed|error)|tcp connect error|dns error|handshake|EOF while parsing|502 Bad Gateway|503 Service|504 Gateway|temporarily unavailable'
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+for attempt in $(seq 1 "$attempts"); do
+  if [[ "$attempt" -gt 1 ]]; then
+    echo "::notice::Retrying deploy of ${service} (attempt ${attempt}/${attempts})"
+  fi
+
+  # tee keeps Railway's build output streaming into the job log in real time
+  # while still capturing it for the pattern check below.
+  railway up --service "$service" 2>&1 | tee "$log"
+  status="${PIPESTATUS[0]}"
+
+  if [[ "$status" -eq 0 ]]; then
+    [[ "$attempt" -gt 1 ]] && echo "::notice::${service} deployed on attempt ${attempt}."
+    exit 0
+  fi
+
+  if ! grep -qiE "$TRANSIENT" "$log"; then
+    echo "::error::Deploying ${service} failed (exit ${status}) and the error is not transient — not retrying."
+    exit "$status"
+  fi
+
+  if [[ "$attempt" -eq "$attempts" ]]; then
+    echo "::error::Deploying ${service} failed ${attempts} times with transport errors. Railway may be degraded — check https://status.railway.com before re-running."
+    exit "$status"
+  fi
+
+  # 10s, 20s, 40s. Long enough for a blip to clear, short enough that a real
+  # outage is obvious quickly.
+  backoff=$((10 * (2 ** (attempt - 1))))
+  echo "Transient failure deploying ${service}; retrying in ${backoff}s."
+  sleep "$backoff"
+done


### PR DESCRIPTION
## What happened

A release is eleven sequential `railway up` calls, each a single point of failure. Today one of them hit a Railway API timeout:

```
reqwest error
  0: error sending request for url (https://backboard.railway.com/graphql/v2)
  1: operation timed out
```

The job stopped there. Four of seven application services were on the new revision, the gateway was still on the old one, and the verification step never ran — so nothing reported what production was actually serving. The deploy itself was fine: the identical step succeeded on retry with no changes.

This release changed no application code, so mixed revisions were harmless. One that changes an RPC contract would not be — that is the outage `RUNBOOK.md` §4 exists to prevent, and this path reaches it **unattended**.

## Changes

**`scripts/ci/railway-up.sh`** — retries transport-shaped failures 3× with 10s/20s backoff.

Retries are deliberately **not** blanket. A failed build fails the same way three times; retrying it burns ten minutes and buries the real error. Non-transient failures exit immediately and say so. Verified against a stubbed CLI:

| case | behaviour |
|---|---|
| transient ×3 | retries, 31s total, clear "Railway may be degraded" message |
| build failure | fails in 0.04s, no retry |
| transient then success | retries once, exits 0 |

**Reports actual production state on any failure.** A partial deploy now says what the gateway is serving instead of ending in silence. It reports rather than asserts (`EXPECTED_RELEASE` unset, `continue-on-error`) so it cannot mask the original failure.

**The failure summary distinguishes the two cases**, because the right response differs: re-run the job when a deploy stopped part-way (`railway up` is idempotent), roll back when the new revision is unhealthy. Previously it assumed the latter.

**`RUNBOOK.md` §4** documents that an interrupted deploy is not automatically a rollback situation.