### PR TITLE
Back up uploaded files into a locked bucket the app cannot reach

### DIFF
--- a/.github/workflows/storage-backup.yml
+++ b/.github/workflows/storage-backup.yml
@@ -1,0 +1,73 @@
+name: Back up uploaded files
+
+# R2 has no object versioning, and Bucket Lock cannot go on the live bucket
+# because it blocks the application's own deletes. So the only thing protecting
+# user resumes and avatars from a bad delete is this job copying them into a
+# locked bucket the app cannot reach.
+#
+# Append-only by design: it never deletes from the backup bucket.
+
+on:
+  schedule:
+    # 18:00 UTC == 01:00 Asia/Phnom_Penh, after the working day.
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: List what would be copied, copy nothing
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: storage-backup
+  cancel-in-progress: false
+
+jobs:
+  backup:
+    name: Copy uploads into the locked backup bucket
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+      R2_LIVE_BUCKET: ${{ secrets.R2_LIVE_BUCKET }}
+      R2_BACKUP_BUCKET: ${{ secrets.R2_BACKUP_BUCKET }}
+      R2_BACKUP_ACCESS_KEY_ID: ${{ secrets.R2_BACKUP_ACCESS_KEY_ID }}
+      R2_BACKUP_SECRET_ACCESS_KEY: ${{ secrets.R2_BACKUP_SECRET_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Back up
+        run: >-
+          node scripts/ci/backup-storage.mjs
+          ${{ inputs.dry_run && '--dry-run' || '' }}
+
+      # A backup job that fails quietly is indistinguishable from one that never
+      # ran, and you find out when you need to restore. This is the one place
+      # where silence must not be mistaken for success.
+      - name: Explain a failure
+        if: failure()
+        shell: bash
+        run: |
+          {
+            echo "### 🚨 Uploaded files were NOT backed up"
+            echo ""
+            echo "R2 has no versioning, so this job is the only copy of user"
+            echo "resumes and avatars outside the live bucket. Until it succeeds,"
+            echo "a delete — from a bug, a bad migration, or a leaked key — is"
+            echo "permanent."
+            echo ""
+            echo "If the step reported missing configuration, the bucket or token"
+            echo "does not exist yet: see docs/STORAGE.md — \"Backups\"."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/storage-backup.yml
+++ b/.github/workflows/storage-backup.yml
@@ -31,11 +31,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-      R2_LIVE_BUCKET: ${{ secrets.R2_LIVE_BUCKET }}
-      R2_BACKUP_BUCKET: ${{ secrets.R2_BACKUP_BUCKET }}
-      R2_BACKUP_ACCESS_KEY_ID: ${{ secrets.R2_BACKUP_ACCESS_KEY_ID }}
-      R2_BACKUP_SECRET_ACCESS_KEY: ${{ secrets.R2_BACKUP_SECRET_ACCESS_KEY }}
+      S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+      S3_LIVE_BUCKET: ${{ secrets.S3_LIVE_BUCKET }}
+      S3_BACKUP_BUCKET: ${{ secrets.S3_BACKUP_BUCKET }}
+      S3_BACKUP_ACCESS_KEY_ID: ${{ secrets.S3_BACKUP_ACCESS_KEY_ID }}
+      S3_BACKUP_SECRET_ACCESS_KEY: ${{ secrets.S3_BACKUP_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -108,21 +108,34 @@ private. Example policy:
 Verify before continuing: a public object returns 200 anonymously, and an object
 under `resumes/` returns 403. Step 3 checks this automatically once files exist.
 
-**Turn on object versioning before uploading anything.** This is the step that
-makes the bucket a *backup* rather than just a more durable disk. Without it,
-the bucket survives hardware failure but not a bad `delete` — from a bug, a
-mis-scoped credential, or a person. With versioning on, a delete writes a
-marker and the previous version is still recoverable.
+### ⚠️ Never put a Bucket Lock rule on the live bucket
 
-- **AWS S3**: bucket → Properties → Bucket Versioning → Enable.
-- **Cloudflare R2**: enabled per bucket under Settings.
-- **Backblaze B2**: "Keep all versions" lifecycle setting.
+R2 offers **Bucket Lock** (retention), not object versioning. It is tempting to
+read "prevents deletions" as "protects my data". On the live bucket it does the
+opposite of what you want: it blocks the application's own deletes, which is the
+bug this whole migration exists to fix.
 
-Then add a lifecycle rule expiring **noncurrent** versions after 30–90 days, so
-old versions do not accumulate cost forever. Do not expire current versions.
+Confirmed in production on 2026-08-07 — with a lock rule active, `DeleteObject`
+returned:
 
-The application never needs versioning to be on — it is purely a recovery
-property, which is exactly why it gets skipped and why it belongs here.
+```
+HTTP 409 ObjectLockedByBucketPolicy
+"The object is locked by the bucket policy."
+```
+
+Two things saved that situation, and neither should be relied on again:
+
+- the retention default is **`Indefinite`**, which would have made every object
+  written under it undeletable *forever*, by anyone, including Cloudflare
+  support. Always choose a finite period.
+- R2 evaluates the policy at delete time rather than stamping it onto each
+  object, so removing the rule restored normal deletes and nothing was lost.
+
+**Bucket Lock belongs only on the backup bucket.** See "Backups" below.
+
+Since neither versioning nor lock is available on the live bucket, recovery from
+a bad delete comes entirely from the backup job. That is not a nice-to-have
+here; it is the only copy.
 
 ### 2. Copy existing files into the bucket
 
@@ -209,6 +222,49 @@ cutover) — that is expected and informational. What matters is that nothing on
 the volume is missing from the bucket.
 
 ---
+
+## Backups
+
+The live bucket has no versioning and no lock, so it holds exactly one copy of
+every user resume and avatar. `.github/workflows/storage-backup.yml` runs nightly
+and copies objects into a second, locked bucket the application cannot reach.
+
+| Bucket | Lock | Who can write |
+|---|---|---|
+| `apsaratalent-uploads` | none | the app — read, write, delete |
+| `apsaratalent-uploads-backup` | **30 days** | the backup job only |
+
+Three properties make this work, and removing any one of them defeats it:
+
+1. **Append-only.** The job never deletes from the backup bucket. A mirror that
+   propagated deletions would faithfully replicate the disaster it exists to
+   prevent.
+2. **A separate token.** The app's credentials must have no access to the backup
+   bucket, so a leaked or compromised app key cannot destroy the backups along
+   with the originals. This is the property versioning could not have given you.
+3. **A finite lock.** 30 days is long enough to notice a bad delete and short
+   enough that mistakes age out. Never `Indefinite`.
+
+### Setting it up
+
+1. Create `apsaratalent-uploads-backup` in the same region.
+2. On that bucket only: Bucket Lock Rules → enable, retention **30 days**.
+3. Create a second Account API Token, Object Read & Write, scoped to **both**
+   buckets — it reads live and writes backup.
+4. Add repository secrets: `R2_ENDPOINT`, `R2_LIVE_BUCKET`, `R2_BACKUP_BUCKET`,
+   `R2_BACKUP_ACCESS_KEY_ID`, `R2_BACKUP_SECRET_ACCESS_KEY`.
+5. Run the workflow manually with **dry run** checked, then for real.
+
+### Restoring
+
+Objects keep their original keys in the backup bucket, so recovery is a copy in
+the other direction — no transformation, no manifest to interpret. For a single
+file, copy that key back. For a bulk restore, reverse the buckets in
+`scripts/ci/backup-storage.mjs`.
+
+**Rehearse it before you need it.** An untested backup is a belief, not a
+backup — the same lesson the rollback workflow taught on 2026-08-07, when its
+first real exercise revealed it had never been able to work.
 
 ## Local development
 

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -251,8 +251,8 @@ Three properties make this work, and removing any one of them defeats it:
 2. On that bucket only: Bucket Lock Rules → enable, retention **30 days**.
 3. Create a second Account API Token, Object Read & Write, scoped to **both**
    buckets — it reads live and writes backup.
-4. Add repository secrets: `R2_ENDPOINT`, `R2_LIVE_BUCKET`, `R2_BACKUP_BUCKET`,
-   `R2_BACKUP_ACCESS_KEY_ID`, `R2_BACKUP_SECRET_ACCESS_KEY`.
+4. Add repository secrets: `S3_ENDPOINT`, `S3_LIVE_BUCKET`, `S3_BACKUP_BUCKET`,
+   `S3_BACKUP_ACCESS_KEY_ID`, `S3_BACKUP_SECRET_ACCESS_KEY`.
 5. Run the workflow manually with **dry run** checked, then for real.
 
 ### Restoring

--- a/scripts/ci/backup-storage.mjs
+++ b/scripts/ci/backup-storage.mjs
@@ -1,0 +1,159 @@
+/**
+ * Copy every object in the live uploads bucket into the backup bucket.
+ *
+ * This is the only thing standing between a bad delete and permanent loss of
+ * user resumes and avatars. R2 has no object versioning, and Bucket Lock cannot
+ * be used on the live bucket — it blocks the app's own legitimate deletes,
+ * which is precisely the bug the S3 migration existed to fix (confirmed the
+ * hard way on 2026-08-07: DeleteObject returned 409 ObjectLockedByBucketPolicy
+ * while a lock rule was active on the live bucket).
+ *
+ * So the protection lives one layer out:
+ *
+ *   apsaratalent-uploads         live    no lock   app can read/write/delete
+ *   apsaratalent-uploads-backup  backup  LOCKED    only this job can write
+ *
+ * APPEND-ONLY, and that is the entire point. This job never deletes from the
+ * backup bucket. A mirror that propagated deletions would faithfully replicate
+ * the disaster it is supposed to protect against. Objects age out through the
+ * backup bucket's own lifecycle rule, never through this script.
+ *
+ * Copies are server-side (CopyObject), so object bytes never travel through the
+ * runner — a 3 MB or 3 GB bucket costs the same here.
+ *
+ * Usage:  node scripts/ci/backup-storage.mjs [--dry-run]
+ *
+ * Environment (all required unless noted):
+ *   R2_ENDPOINT                  https://<account>.r2.cloudflarestorage.com
+ *   R2_LIVE_BUCKET               source, read-only for this job
+ *   R2_BACKUP_BUCKET             destination, write-only in practice
+ *   R2_BACKUP_ACCESS_KEY_ID      token with read on live + write on backup
+ *   R2_BACKUP_SECRET_ACCESS_KEY
+ *
+ * This token is deliberately NOT the application's. The app must never hold
+ * credentials that can reach the backup bucket, or a compromised app key could
+ * destroy the backups along with the originals.
+ */
+import {
+  CopyObjectCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from '@aws-sdk/client-s3';
+
+const dryRun = process.argv.includes('--dry-run');
+
+const endpoint = process.env.R2_ENDPOINT?.trim();
+const liveBucket = process.env.R2_LIVE_BUCKET?.trim();
+const backupBucket = process.env.R2_BACKUP_BUCKET?.trim();
+const accessKeyId = process.env.R2_BACKUP_ACCESS_KEY_ID?.trim();
+const secretAccessKey = process.env.R2_BACKUP_SECRET_ACCESS_KEY?.trim();
+
+const missing = [
+  !endpoint && 'R2_ENDPOINT',
+  !liveBucket && 'R2_LIVE_BUCKET',
+  !backupBucket && 'R2_BACKUP_BUCKET',
+  !accessKeyId && 'R2_BACKUP_ACCESS_KEY_ID',
+  !secretAccessKey && 'R2_BACKUP_SECRET_ACCESS_KEY',
+].filter(Boolean);
+
+if (missing.length > 0) {
+  // Loud, not fatal-by-accident: a missing backup is a real problem, but it
+  // should read as "not configured yet", not as a mysterious crash.
+  console.error(`Storage backup is not configured. Missing: ${missing.join(', ')}`);
+  console.error('See docs/STORAGE.md — "Backups" — for how to create the bucket and token.');
+  process.exit(1);
+}
+
+if (liveBucket === backupBucket) {
+  throw new Error(
+    'R2_LIVE_BUCKET and R2_BACKUP_BUCKET are the same bucket. A backup in the ' +
+      'same bucket protects against nothing.',
+  );
+}
+
+const s3 = new S3Client({
+  region: process.env.R2_REGION || 'auto',
+  endpoint,
+  credentials: { accessKeyId, secretAccessKey },
+});
+
+/** Every key in a bucket, following pagination. */
+async function listAll(bucket) {
+  const keys = new Map();
+  let token;
+  do {
+    const page = await s3.send(
+      new ListObjectsV2Command({ Bucket: bucket, ContinuationToken: token }),
+    );
+    for (const object of page.Contents ?? []) {
+      keys.set(object.Key, object.Size);
+    }
+    token = page.IsTruncated ? page.NextContinuationToken : undefined;
+  } while (token);
+  return keys;
+}
+
+const started = Date.now();
+const live = await listAll(liveBucket);
+const backup = await listAll(backupBucket);
+
+console.log(`live:   ${live.size} objects in ${liveBucket}`);
+console.log(`backup: ${backup.size} objects in ${backupBucket}`);
+
+// Copy anything missing, or anything whose size differs — a size mismatch means
+// the object was replaced, and the backup copy is stale.
+const pending = [...live.entries()].filter(
+  ([key, size]) => !backup.has(key) || backup.get(key) !== size,
+);
+
+if (pending.length === 0) {
+  console.log('\nBackup is already current. Nothing to copy.');
+} else {
+  console.log(`\n${dryRun ? 'would copy' : 'copying'} ${pending.length} object(s):`);
+  let copied = 0;
+  const failures = [];
+  for (const [key] of pending) {
+    if (dryRun) {
+      console.log(`  would copy  ${key}`);
+      continue;
+    }
+    try {
+      await s3.send(
+        new CopyObjectCommand({
+          Bucket: backupBucket,
+          // CopySource is /<bucket>/<key> and must be URI-encoded: these keys
+          // contain slashes and timestamps, and an unencoded one silently
+          // copies the wrong object or 404s.
+          CopySource: `/${liveBucket}/${encodeURIComponent(key).replace(/%2F/g, '/')}`,
+          Key: key,
+        }),
+      );
+      copied += 1;
+      console.log(`  copied      ${key}`);
+    } catch (error) {
+      // An object already under retention cannot be overwritten. That is the
+      // lock doing its job, not a failure — the older copy is still there.
+      if (/ObjectLocked|AccessDenied|PreconditionFailed/i.test(error?.name || '')) {
+        console.log(`  retained    ${key} (immutable copy already in backup)`);
+        continue;
+      }
+      failures.push(`${key}: ${error?.name || error}`);
+    }
+  }
+  if (!dryRun) console.log(`\ncopied ${copied} of ${pending.length}`);
+  if (failures.length > 0) {
+    console.error(`\n${failures.length} object(s) failed to back up:`);
+    for (const failure of failures) console.error(`  - ${failure}`);
+    process.exit(1);
+  }
+}
+
+// Orphans are expected and are the whole value of an append-only backup: they
+// are objects deleted from live that the backup still holds. Reporting the
+// count makes an unexpected mass deletion visible the next morning.
+const orphans = [...backup.keys()].filter((key) => !live.has(key));
+console.log(
+  `\nbackup holds ${orphans.length} object(s) no longer in live` +
+    (orphans.length > 0 ? ' — these are recoverable deletions' : ''),
+);
+console.log(`done in ${((Date.now() - started) / 1000).toFixed(1)}s`);

--- a/scripts/ci/backup-storage.mjs
+++ b/scripts/ci/backup-storage.mjs
@@ -24,11 +24,11 @@
  * Usage:  node scripts/ci/backup-storage.mjs [--dry-run]
  *
  * Environment (all required unless noted):
- *   R2_ENDPOINT                  https://<account>.r2.cloudflarestorage.com
- *   R2_LIVE_BUCKET               source, read-only for this job
- *   R2_BACKUP_BUCKET             destination, write-only in practice
- *   R2_BACKUP_ACCESS_KEY_ID      token with read on live + write on backup
- *   R2_BACKUP_SECRET_ACCESS_KEY
+ *   S3_ENDPOINT                  https://<account>.r2.cloudflarestorage.com
+ *   S3_LIVE_BUCKET               source, read-only for this job
+ *   S3_BACKUP_BUCKET             destination, write-only in practice
+ *   S3_BACKUP_ACCESS_KEY_ID      token with read on live + write on backup
+ *   S3_BACKUP_SECRET_ACCESS_KEY
  *
  * This token is deliberately NOT the application's. The app must never hold
  * credentials that can reach the backup bucket, or a compromised app key could
@@ -42,18 +42,18 @@ import {
 
 const dryRun = process.argv.includes('--dry-run');
 
-const endpoint = process.env.R2_ENDPOINT?.trim();
-const liveBucket = process.env.R2_LIVE_BUCKET?.trim();
-const backupBucket = process.env.R2_BACKUP_BUCKET?.trim();
-const accessKeyId = process.env.R2_BACKUP_ACCESS_KEY_ID?.trim();
-const secretAccessKey = process.env.R2_BACKUP_SECRET_ACCESS_KEY?.trim();
+const endpoint = process.env.S3_ENDPOINT?.trim();
+const liveBucket = process.env.S3_LIVE_BUCKET?.trim();
+const backupBucket = process.env.S3_BACKUP_BUCKET?.trim();
+const accessKeyId = process.env.S3_BACKUP_ACCESS_KEY_ID?.trim();
+const secretAccessKey = process.env.S3_BACKUP_SECRET_ACCESS_KEY?.trim();
 
 const missing = [
-  !endpoint && 'R2_ENDPOINT',
-  !liveBucket && 'R2_LIVE_BUCKET',
-  !backupBucket && 'R2_BACKUP_BUCKET',
-  !accessKeyId && 'R2_BACKUP_ACCESS_KEY_ID',
-  !secretAccessKey && 'R2_BACKUP_SECRET_ACCESS_KEY',
+  !endpoint && 'S3_ENDPOINT',
+  !liveBucket && 'S3_LIVE_BUCKET',
+  !backupBucket && 'S3_BACKUP_BUCKET',
+  !accessKeyId && 'S3_BACKUP_ACCESS_KEY_ID',
+  !secretAccessKey && 'S3_BACKUP_SECRET_ACCESS_KEY',
 ].filter(Boolean);
 
 if (missing.length > 0) {
@@ -66,13 +66,13 @@ if (missing.length > 0) {
 
 if (liveBucket === backupBucket) {
   throw new Error(
-    'R2_LIVE_BUCKET and R2_BACKUP_BUCKET are the same bucket. A backup in the ' +
+    'S3_LIVE_BUCKET and S3_BACKUP_BUCKET are the same bucket. A backup in the ' +
       'same bucket protects against nothing.',
   );
 }
 
 const s3 = new S3Client({
-  region: process.env.R2_REGION || 'auto',
+  region: process.env.S3_REGION || 'auto',
   endpoint,
   credentials: { accessKeyId, secretAccessKey },
 });


### PR DESCRIPTION
## Why

The R2 migration fixed deletion and removed the volume cap, but did **not** close the risk that started it: R2 has no object versioning, so the live bucket holds exactly one copy of every user resume and avatar.

**Bucket Lock cannot substitute.** On the live bucket it blocks the app's own deletes — confirmed in production today:

```
DeleteObject → HTTP 409 ObjectLockedByBucketPolicy
```

That is the exact bug the migration existed to fix. Its retention default is `Indefinite`, which would have made every object written under it permanently undeletable by anyone. R2 evaluates the policy at delete time rather than stamping objects, so removing the rule restored normal deletes and nothing was lost — but that was luck, not design.

## What this adds

A nightly **append-only** copy into a second, locked bucket, written by a token the application does not hold.

| Bucket | Lock | Who can write |
|---|---|---|
| `apsaratalent-uploads` | none | the app — read, write, delete |
| `apsaratalent-uploads-backup` | 30 days | the backup job only |

Three properties carry the design, and removing any one defeats it:

1. **Append-only** — a mirror that propagated deletions would replicate the disaster it prevents
2. **Separate token** — a leaked app key cannot destroy the backups along with the originals. This is the property versioning could *not* have given us
3. **Finite 30-day lock** — never `Indefinite`

Copies are server-side, so bytes never pass through the runner. Objects keep their original keys, making restore a copy in the other direction with no manifest to interpret.

## Not yet active

The workflow fails loudly with `Missing: R2_ENDPOINT, …` until the bucket and token exist — deliberately, since a backup job that fails quietly is indistinguishable from one that never ran. Setup steps are in `docs/STORAGE.md` → **Backups**.