### PR TITLE
Stop the Railway volume from swallowing Grafana's dashboards

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       PROMETHEUS_URL: http://prometheus:9090
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
-      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - ./grafana/dashboards:/etc/grafana/dashboards:ro
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -9,5 +9,5 @@ providers:
     updateIntervalSeconds: 30
     allowUiUpdates: true
     options:
-      path: /var/lib/grafana/dashboards
+      path: /etc/grafana/dashboards
       foldersFromFilesStructure: false

--- a/monitoring/production/README.md
+++ b/monitoring/production/README.md
@@ -29,6 +29,14 @@ Required configuration:
   exporter `9115`, and Grafana `3000`.
 - Add persistent Railway volumes at `/prometheus`, `/alertmanager`, and
   `/var/lib/grafana` respectively.
+- **Nothing baked into the image may live under a volume mount path.** A Railway
+  volume shadows whatever the image placed there. Grafana's dashboards were
+  originally copied to `/var/lib/grafana/dashboards` — directly under its volume
+  — so they disappeared at runtime and the provisioned dashboard never once
+  loaded, while Grafana logged `failed to walk provisioned dashboards` every 30
+  seconds. They now live at `/etc/grafana/dashboards`, which is not a mount
+  point. The same rule applies to any config added to Prometheus or Alertmanager
+  under `/prometheus` or `/alertmanager`.
 - Do not create public domains for Prometheus, Alertmanager, or blackbox. If a
   Grafana domain is required, protect it with TLS and strong authentication.
 - Leave `PORT` **unset** on the six internal API services. Railway injects

--- a/monitoring/production/grafana/Dockerfile
+++ b/monitoring/production/grafana/Dockerfile
@@ -1,6 +1,11 @@
 FROM grafana/grafana:13.1.3
 
 COPY --chown=grafana:grafana monitoring/grafana/provisioning /etc/grafana/provisioning
-COPY --chown=grafana:grafana monitoring/grafana/dashboards /var/lib/grafana/dashboards
+# NOT /var/lib/grafana/dashboards. Railway mounts the Grafana volume at
+# /var/lib/grafana, which shadows everything the image put there — so dashboards
+# copied to that path vanish at runtime and Grafana logs "failed to walk
+# provisioned dashboards" every 30s, forever, with no dashboard ever appearing.
+# /etc/grafana is not a mount point, so content there survives.
+COPY --chown=grafana:grafana monitoring/grafana/dashboards /etc/grafana/dashboards
 
 USER grafana


### PR DESCRIPTION
## The bug

The Grafana image copies dashboards to `/var/lib/grafana/dashboards` — which is exactly where Railway mounts Grafana's volume. The mount shadows whatever the image put there, so **the provisioned Apsara Talent dashboard has never once loaded.**

Grafana has been logging this every 30 seconds since the stack was built:

```
failed to walk provisioned dashboards
error="stat /var/lib/grafana/dashboards: no such file or directory"
```

Confirmed inside the running container:

```
RAILWAY_VOLUME_MOUNT_PATH=/var/lib/grafana
ls /var/lib/grafana/dashboards → No such file or directory
lost+found present            → it is a real filesystem mount
```

## The fix

Dashboards move to `/etc/grafana/dashboards`, which is not a mount point. Three files change together so dev and production cannot drift apart:

- `monitoring/production/grafana/Dockerfile` — the COPY target
- `monitoring/grafana/provisioning/dashboards/dashboards.yml` — `options.path`
- `monitoring/docker-compose.yml` — the local bind mount

## How this was missed

`docs/PRODUCTION-ROLLOUT.md` §3 already says *"Confirm the provisioned Apsara Talent dashboard loads in Grafana."* That step would have caught it on day one.

The monitoring README now states the general rule, because the same trap applies to anything placed under `/prometheus` or `/alertmanager`.

## Note on the deploy failure that surfaced this

The Grafana deploy failure was **unrelated**. Its build log ends at `scheduling build on Metal builder` with no output, the same Dockerfile built fine two hours earlier, and Railway kept the previous working revision — a Railway-side infrastructure failure.

The retry wrapper from #71 correctly classified it as non-transient and refused to burn three build cycles on it.
