### PR TITLE
Stop the backup job reporting success when it copies nothing

### DIFF
--- a/scripts/ci/backup-storage.mjs
+++ b/scripts/ci/backup-storage.mjs
@@ -131,13 +131,32 @@ if (pending.length === 0) {
       copied += 1;
       console.log(`  copied      ${key}`);
     } catch (error) {
+      const name = error?.name || '';
+
       // An object already under retention cannot be overwritten. That is the
-      // lock doing its job, not a failure — the older copy is still there.
-      if (/ObjectLocked|AccessDenied|PreconditionFailed/i.test(error?.name || '')) {
+      // lock doing its job — but only when a copy genuinely already exists.
+      // Requiring backup.has(key) is what keeps this from excusing a failure
+      // that left nothing behind.
+      if (/ObjectLocked|PreconditionFailed/i.test(name) && backup.has(key)) {
         console.log(`  retained    ${key} (immutable copy already in backup)`);
         continue;
       }
-      failures.push(`${key}: ${error?.name || error}`);
+
+      // AccessDenied was originally treated as benign here, alongside the lock.
+      // It is the opposite: it means the token cannot write, so NOTHING is
+      // being backed up — and the job would have reported success while copying
+      // nothing at all. Found on 2026-08-08 with a token issued as "Object Read
+      // only". A backup that lies about succeeding is worse than no backup,
+      // because it stops anyone looking.
+      if (/AccessDenied|Unauthorized|InvalidAccessKeyId|SignatureDoesNotMatch/i.test(name)) {
+        failures.push(
+          `${key}: ${name} — the backup token cannot write to ${backupBucket}. ` +
+            'It needs Object Read & Write, not Read only.',
+        );
+        continue;
+      }
+
+      failures.push(`${key}: ${name || error}`);
     }
   }
   if (!dryRun) console.log(`\ncopied ${copied} of ${pending.length}`);


### PR DESCRIPTION
## The bug

`AccessDenied` was grouped with `ObjectLocked` and logged as *"retained (immutable copy already in backup)"*. Those two are opposites:

- **ObjectLocked** — a copy is already there and protected. Benign.
- **AccessDenied** — the token cannot write. **Nothing is being backed up.**

So a backup job with a read-only token would log every object as "retained" and **exit 0**, reporting success while copying nothing.

## How it was found

The backup token had been issued as **Object Read only**. Every `CopyObject` would have been silently swallowed. The bucket happened to already contain the 16 files (copied by other means), so the job reported "already current" and nobody would have noticed until a restore.

The workflow's own failure notice says:

> A backup job that fails quietly is indistinguishable from one that never ran, and you find out when you need to restore.

This script had exactly that bug.

## The fix

| Error | Before | After |
|---|---|---|
| `ObjectLocked` + key present in backup | retained | retained ✅ |
| `ObjectLocked` + key **absent** | retained ❌ | **failure** |
| `AccessDenied` / `Unauthorized` | retained ❌ | **failure, names the cause** |
| anything else | failure | failure |

`ObjectLocked` is now only benign when `backup.has(key)` — a lock error can no longer excuse a copy that left nothing behind.
