### PR TITLE
Publish built images to GHCR (step 1 of build-once-deploy-many)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -169,6 +169,8 @@ jobs:
       contents: read
       # Required to publish scan results to the repository's Security tab.
       security-events: write
+      # Required to push the built image to GHCR.
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -183,12 +185,25 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Tagged with the commit SHA and pushed on main, so the artifact that was
+      # built, scanned and (soon) deployed is one immutable thing rather than
+      # three separate rebuilds that happen to come from the same source.
       - name: Build production container
         run: >-
           docker build
           --file apps/${{ matrix.service }}/Dockerfile
-          --tag apsaratalent/${{ matrix.service }}:${{ github.sha }}
+          --tag ghcr.io/rithybondeth/apsaratalent-${{ matrix.service }}:${{ github.sha }}
           .
+
+      # Only from main. A pull request builds and scans the identical image but
+      # must not be able to publish one.
+      - name: Publish to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker push "ghcr.io/rithybondeth/apsaratalent-${{ matrix.service }}:${{ github.sha }}"
+          docker logout ghcr.io
 
       # The image is scanned, not merely built. `npm audit` sees the JavaScript
       # dependency tree only — nothing before this step looks at the Alpine base
@@ -198,7 +213,7 @@ jobs:
       - name: Scan image for vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: apsaratalent/${{ matrix.service }}:${{ github.sha }}
+          image-ref: ghcr.io/rithybondeth/apsaratalent-${{ matrix.service }}:${{ github.sha }}
           format: sarif
           output: trivy-${{ matrix.service }}.sarif
           severity: HIGH,CRITICAL
@@ -218,7 +233,7 @@ jobs:
       - name: Fail on fixable critical vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: apsaratalent/${{ matrix.service }}:${{ github.sha }}
+          image-ref: ghcr.io/rithybondeth/apsaratalent-${{ matrix.service }}:${{ github.sha }}
           format: table
           severity: CRITICAL
           ignore-unfixed: true
@@ -309,6 +324,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -320,8 +336,16 @@ jobs:
         run: >-
           docker build
           --file monitoring/production/${{ matrix.service }}/Dockerfile
-          --tag apsaratalent/monitoring-${{ matrix.service }}:${{ github.sha }}
+          --tag ghcr.io/rithybondeth/apsaratalent-monitoring-${{ matrix.service }}:${{ github.sha }}
           .
+
+      - name: Publish to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker push "ghcr.io/rithybondeth/apsaratalent-monitoring-${{ matrix.service }}:${{ github.sha }}"
+          docker logout ghcr.io
 
       # These four are upstream images with a config layer on top, so their CVEs
       # arrive entirely through base image bumps — exactly the class npm audit
@@ -329,7 +353,7 @@ jobs:
       - name: Scan image for vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: apsaratalent/monitoring-${{ matrix.service }}:${{ github.sha }}
+          image-ref: ghcr.io/rithybondeth/apsaratalent-monitoring-${{ matrix.service }}:${{ github.sha }}
           format: sarif
           output: trivy-monitoring-${{ matrix.service }}.sarif
           severity: HIGH,CRITICAL
@@ -345,7 +369,7 @@ jobs:
       - name: Fail on fixable critical vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: apsaratalent/monitoring-${{ matrix.service }}:${{ github.sha }}
+          image-ref: ghcr.io/rithybondeth/apsaratalent-monitoring-${{ matrix.service }}:${{ github.sha }}
           format: table
           severity: CRITICAL
           ignore-unfixed: true


### PR DESCRIPTION
Step 1 of build-once-deploy-many.

## The problem, including the part usually missed

CI builds 11 images, proves they build, scans them — then throws them away. Railway rebuilds from source on deploy.

- the container that was **tested** is not the container that ships
- the container that was **scanned** is not the container that ships

That second one matters more than it sounds. The Trivy gate merged yesterday is currently guarding an artifact nobody runs. If a base image tag moved between the CI build and Railway's build, the scan proved nothing about production.

## What this changes

Every image is tagged `ghcr.io/rithybondeth/apsaratalent-<service>:<sha>` and pushed from `main`. The scan and the fail-on-critical gate both point at that exact tag.

Verified mechanically that build, push, scan and gate all reference the same string, for both the 7 app images and the 4 monitoring images.

Pull requests build and scan the identical image but cannot publish — `packages: write` plus a branch condition.

## What this deliberately does NOT change

The deploy job still uses `railway up`.

Railway *can* deploy a registry image — `railway service source connect --image <ref> --service <name>` exists and accepts a per-commit tag, so digest-pinned deploys are achievable. But it is **not yet established whether `railway redeploy --from-source` blocks until the service is healthy**, the way `railway up` in CI mode does.

If it returns immediately, switching the deploy path would silently drop per-service health verification from every release — a regression wearing the costume of an improvement. Given that four safety mechanisms in this repo turned out to be broken the first time they were exercised, that assumption gets tested against a real service before the deploy job changes.

**Cost of splitting it this way:** one extra image build per release until step 2 lands. That is the price of being able to verify step 2 with real images rather than guessing.

## Step 2 — after this merges

1. Confirm GHCR package visibility (the repo is public, so public packages leak nothing new and avoid configuring registry credentials in Railway)
2. Point one low-risk service at its GHCR image by hand and observe whether the deploy blocks and whether health is verified
3. If it blocks: switch all 11 and delete the rebuild
4. If it does not: add an explicit health wait before switching

Expected once complete: deploys drop from ~40 minutes to roughly half.
