### PR TITLE
Count rows for real in the restore drill

### DIFF
--- a/scripts/ci/db-restore-drill.mjs
+++ b/scripts/ci/db-restore-drill.mjs
@@ -88,11 +88,19 @@ async function neon(path, { method = 'GET', body } = {}) {
   throw new Error(`Neon API ${method} ${path} failed: ${lastError}`);
 }
 
-/** Schema-qualified row counts, the cheapest meaningful "is the data there". */
-const COUNT_SQL = `
-  SELECT relname AS table, n_live_tup AS rows
-  FROM pg_stat_user_tables
-  ORDER BY relname
+// Real COUNT(*), not pg_stat_user_tables.n_live_tup.
+//
+// n_live_tup is a statistics estimate maintained by autovacuum/ANALYZE. A
+// freshly created Neon branch has no statistics gathered yet, so EVERY table
+// reads as 0 rows no matter what it actually contains — which made the first
+// drill run report 20 tables as "empty in restore" when the data was there all
+// along. At this database size (13 MB, 27 tables) counting for real costs
+// milliseconds and cannot lie.
+const TABLES_SQL = `
+  SELECT table_name
+  FROM information_schema.tables
+  WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+  ORDER BY table_name
 `;
 
 async function inspect(connectionString, label) {
@@ -107,7 +115,17 @@ async function inspect(connectionString, label) {
   await client.connect();
   const connectedMs = Date.now() - startedAt;
   try {
-    const tables = await client.query(COUNT_SQL);
+    const names = await client.query(TABLES_SQL);
+    const counts = [];
+    for (const { table_name: name } of names.rows) {
+      // Identifier is quoted, and comes from information_schema rather than
+      // anything user-supplied.
+      const { rows } = await client.query(
+        `SELECT count(*)::int AS rows FROM "${name.replace(/"/g, '""')}"`,
+      );
+      counts.push({ table: name, rows: rows[0].rows });
+    }
+    const tables = { rows: counts };
     const size = await client.query(
       'SELECT pg_size_pretty(pg_database_size(current_database())) AS size',
     );


### PR DESCRIPTION
The first restore drill run reported **20 tables as "empty in restore"** while the data was actually present.

The comparison used `pg_stat_user_tables.n_live_tup`, a statistics estimate maintained by autovacuum. A freshly created Neon branch has gathered no statistics yet, so every table reads as zero regardless of what it contains.

A verification that cries wolf on a healthy restore is worse than no verification — during a real incident someone would see 20 failures and have to decide, under pressure, whether to believe them.

`COUNT(*)` cannot lie, and at 13 MB across 27 tables it costs milliseconds.

## The restore itself worked first time

```
branch created in 0.8s
restored: 27 tables, 12 migrations applied, 10136 kB
```

Under two seconds, correct schema, correct migration count. **That is your restore time** — the number RUNBOOK §7 has listed as unknown since the project started.