### PR TITLE
feat(migrations): add db:rehearse command and CI workflow for migrati…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -403,11 +403,75 @@ jobs:
             fi
           done
 
+  migration-rehearsal:
+    name: Rehearse migrations against production data
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: [release-preflight]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Runs on a copy-on-write branch of production, so this is read-only with
+      # respect to the live database and costs seconds regardless of size.
+      #
+      # Deliberately placed BEFORE `migrate`, and gating it. The restore point
+      # that job takes is recovery; this is prevention — and the Neon
+      # point-in-time window behind that restore point is 1 day, so a migration
+      # that fails on real rows is much cheaper to discover here.
+      #
+      # No DATABASE_URL: the script sets it per command to the branch it created,
+      # which is what makes it structurally unable to migrate production.
+      - name: Rehearse this release's migrations
+        run: npm run db:rehearse
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
+
+      - name: Explain a failure
+        if: failure()
+        shell: bash
+        run: |
+          {
+            echo "### ❌ Migrations did not survive rehearsal"
+            echo ""
+            echo "This release's migrations were applied to a copy-on-write branch of"
+            echo "production and something failed. **Production was not touched** and"
+            echo "no migration ran against it — the \`migrate\` job never started."
+            echo ""
+            echo "The step above names the phase. What each one means:"
+            echo ""
+            echo "- **Forward** — the migration does not apply to the rows that are"
+            echo "  actually in production. A NOT NULL over existing nulls, a UNIQUE"
+            echo "  index over duplicates, a narrowing that overflows. Unit tests"
+            echo "  cannot see this; they run against a mocked QueryRunner."
+            echo "- **Reverse** — \`down()\` is broken. Fix it before shipping: it is"
+            echo "  the first move in docs/RUNBOOK.md §5, and a rollback you cannot"
+            echo "  perform is not a rollback."
+            echo "- **Re-apply** — the migration is reversible once but not twice,"
+            echo "  so revert-fix-redeploy would fail on the redeploy."
+            echo ""
+            echo "Reproduce locally against your own Neon branch:"
+            echo ""
+            echo '```bash'
+            echo "REHEARSAL_KEEP_BRANCH=1 npm run db:rehearse"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   migrate:
     name: Run production database migrations
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [release-preflight]
+    needs: [release-preflight, migration-rehearsal]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v7

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -18,15 +18,46 @@ a `migrations` table so the database knows what has and hasn't run.
 | `npm run migration:create migrations/DescribeTheChange` | Scaffold a new empty migration |
 | `npm run migration:baseline` | Dry run: show what baselining would record |
 | `npm run migration:baseline -- --apply` | Record migrations as applied **without running them** |
+| `npm run db:rehearse` | Apply, revert and re-apply pending migrations on a throwaway branch of production |
 
-All of these read `DATABASE_URL`. `dotenv` does **not** override variables that
-are already set, so an explicit `DATABASE_URL=... npm run migration:run` always
-wins over `.env`.
+All of these read `DATABASE_URL`, except `db:rehearse` — see below. `dotenv`
+does **not** override variables that are already set, so an explicit
+`DATABASE_URL=... npm run migration:run` always wins over `.env`.
 
 > **Always check which database you are pointed at before running anything.**
 > With no `DATABASE_URL` in the environment, these commands silently fall back
 > to whatever is in `.env` — which is very likely not the one you meant.
 > `migration:baseline` prints its target host and database for this reason.
+
+## Rehearsing before you migrate
+
+`npm run db:rehearse` answers the question the unit tests cannot: *will this
+migration apply to the rows that are actually in production?*
+`migrations.spec.ts` calls `up()` and `down()` against a mocked QueryRunner, so
+it proves the SQL exists but never executes it. A NOT NULL over existing nulls,
+a UNIQUE index over duplicates, or a backfill that overflows only fails on real
+rows.
+
+It reads `NEON_API_KEY` and `NEON_PROJECT_ID`, **not** `DATABASE_URL`. It
+branches production copy-on-write, then sets `DATABASE_URL` itself per command
+to point at that branch — which is what makes it structurally unable to migrate
+production, and why it is safe to run by hand at any time. The branch and its
+compute are deleted on the way out, including when a phase fails; pass
+`REHEARSAL_KEEP_BRANCH=1` to keep it for inspection.
+
+Three phases run, in order: `migration:run`, then `migration:revert` once per
+pending migration, then `migration:run` again. The last one matters because
+revert-fix-redeploy is the sequence RUNBOOK §5 prescribes, and a `down()` that
+drops a column while leaving its index behind is reversible exactly once.
+
+The revert phase is skipped when this release includes a migration listed as
+intentionally irreversible (`NormalizeExperienceLevels`, `HashRefreshTokens`) —
+reverting past one proves nothing, and for the second it would mean writing
+plaintext refresh tokens back. That list is duplicated in
+`scripts/ci/migration-rehearsal.mjs`; keep it in step with the `irreversible`
+array in `migrations.spec.ts`.
+
+This runs in CI on every push to `main`, gating the `migrate` job.
 
 ## First-time rollout against the existing production database
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "migration:baseline": "ts-node -r tsconfig-paths/register scripts/db/baseline-migrations.ts",
     "db:backup": "./scripts/db/backup-db.sh",
     "db:restore-point": "node --env-file-if-exists=.env scripts/ci/create-restore-point.mjs",
+    "db:rehearse": "node --env-file-if-exists=.env scripts/ci/migration-rehearsal.mjs",
     "storage:migrate": "ts-node -r tsconfig-paths/register scripts/storage/migrate-storage-to-s3.ts",
     "storage:verify": "ts-node -r tsconfig-paths/register scripts/storage/verify-storage-migration.ts",
     "seed": "ts-node -r tsconfig-paths/register scripts/db/seed.ts",

--- a/scripts/ci/migration-rehearsal.mjs
+++ b/scripts/ci/migration-rehearsal.mjs
@@ -1,0 +1,453 @@
+/**
+ * Rehearse this release's migrations against real production data, before they
+ * touch production.
+ *
+ * Nothing in the pipeline currently answers "will this migration apply to the
+ * rows that are actually in the database?". `migrations.spec.ts` calls `up()`
+ * and `down()` against a mocked QueryRunner, which proves the SQL strings exist
+ * and are non-empty — it never executes them, so it cannot see a NOT NULL added
+ * to a column containing nulls, a UNIQUE index over existing duplicates, a type
+ * narrowing that overflows, or a backfill that deadlocks against live-shaped
+ * data. Those only appear on real rows, and today they would appear for the
+ * first time in the `migrate` job, against production, behind a Neon restore
+ * point whose point-in-time window is 1 day.
+ *
+ * `migration:revert` is in the same position, and worse: it has never been
+ * executed at all. It is the documented first move in RUNBOOK §5, and on
+ * 2026-08-07 every safety mechanism in this system that had never been
+ * exercised turned out to be broken.
+ *
+ * So this rehearses the whole sequence on a copy-on-write branch:
+ *
+ *   1. branch production at its current state (never touches the live branch)
+ *   2. work out which migrations this release adds, by comparing the files on
+ *      disk to the branch's own `migrations` table
+ *   3. `migration:run`   — the forward path, on real rows
+ *   4. `migration:revert` x N — the rollback path, unless a migration in this
+ *      release is declared irreversible
+ *   5. `migration:run`   — re-apply, because revert-then-redeploy is the actual
+ *      incident sequence and a migration can be reversible once but not twice
+ *   6. delete the branch
+ *
+ * Read-only with respect to production: every write lands on the branch. Neon
+ * branches are copy-on-write, so this costs seconds rather than a full copy,
+ * which is why it can gate every release instead of never running.
+ *
+ *   node scripts/ci/migration-rehearsal.mjs
+ *
+ * Environment:
+ *   NEON_API_KEY, NEON_PROJECT_ID   (required) control-plane access
+ *   NEON_PARENT_BRANCH              branch to copy. Defaults to the project default.
+ *   REHEARSAL_KEEP_BRANCH           set to 1 to leave the branch for inspection
+ */
+import { spawn } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { appendFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { Client } from 'pg';
+
+const API_BASE = process.env.NEON_API_BASE || 'https://console.neon.tech/api/v2';
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+// Reserved namespace, mirroring create-restore-point.mjs and
+// db-restore-drill.mjs. Cleanup only ever considers branches under this prefix,
+// so a human's branch is never at risk.
+const PREFIX = 'ci-migration-rehearsal/';
+
+// Migrations whose `down()` is deliberately a no-op, so reverting past them
+// proves nothing and the revert phase is skipped when one is in this release.
+//
+// This list is the second copy of the one in `migrations/migrations.spec.ts`
+// (`irreversible`), which names them in prose. Keep the two in step; better
+// still, give the migration classes a static marker both can read.
+//
+//   NormalizeExperienceLevels — the original free-text experience levels are
+//     gone once normalized; there is nothing to restore them from.
+//   HashRefreshTokens         — reversing it would write bearer credentials
+//     back in plaintext, which is the vulnerability it exists to remove.
+const IRREVERSIBLE = new Set([
+  'NormalizeExperienceLevels1781136000000',
+  'HashRefreshTokens1784073600000',
+]);
+
+const apiKey = process.env.NEON_API_KEY?.trim();
+const projectId = process.env.NEON_PROJECT_ID?.trim();
+
+if (!apiKey || !projectId) {
+  throw new Error(
+    'NEON_API_KEY and NEON_PROJECT_ID are both required. A production migration ' +
+      'must not run without having been rehearsed — see docs/RUNBOOK.md.',
+  );
+}
+
+async function neon(path, { method = 'GET', body } = {}) {
+  const url = `${API_BASE}/projects/${encodeURIComponent(projectId)}${path}`;
+  let lastError = 'no attempt made';
+
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    let response;
+    try {
+      response = await fetch(url, {
+        method,
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          accept: 'application/json',
+          ...(body ? { 'content-type': 'application/json' } : {}),
+        },
+        body: body ? JSON.stringify(body) : undefined,
+        signal: AbortSignal.timeout(60_000),
+      });
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+      await new Promise((r) => setTimeout(r, attempt * 3_000));
+      continue;
+    }
+    // 423 Locked means another project operation is in flight; 429 and 5xx are
+    // likewise transient. Same policy as create-restore-point.mjs.
+    if (response.status === 423 || response.status === 429 || response.status >= 500) {
+      lastError = `HTTP ${response.status}`;
+      await new Promise((r) => setTimeout(r, attempt * 3_000));
+      continue;
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Neon API ${method} ${path} failed: HTTP ${response.status} ${(await response.text()).slice(0, 300)}`,
+      );
+    }
+    return response.status === 204 ? {} : response.json();
+  }
+  throw new Error(`Neon API ${method} ${path} failed: ${lastError}`);
+}
+
+/**
+ * The migrations on disk, in execution order.
+ *
+ * `1786003200000-AddLoginHistory.ts` describes the class
+ * `AddLoginHistory1786003200000` — the convention `migration:create` generates
+ * and the one `migrations.spec.ts` imports by. The glob matches data-source.ts
+ * (`migrations/[0-9]*.ts`), so colocated specs and the README are excluded.
+ */
+function migrationsOnDisk() {
+  return readdirSync(new URL('../../migrations', import.meta.url))
+    .filter((file) => /^\d+-.+\.ts$/.test(file))
+    .map((file) => {
+      const [, timestamp, label] = file.match(/^(\d+)-(.+)\.ts$/);
+      return { timestamp, name: `${label}${timestamp}`, file };
+    })
+    .sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
+}
+
+/**
+ * Timestamps recorded in the branch's own `migrations` table.
+ *
+ * Matched on timestamp rather than name: the timestamp is what TypeORM orders
+ * and de-duplicates by, and it survives a class being renamed.
+ */
+async function appliedTimestamps(connectionString) {
+  const client = new Client({
+    connectionString,
+    // Neon requires TLS; CI runners have the CA bundle.
+    ssl: { rejectUnauthorized: true },
+    connectionTimeoutMillis: 30_000,
+    statement_timeout: 60_000,
+  });
+  await client.connect();
+  try {
+    const { rows } = await client.query(
+      "SELECT to_regclass('public.migrations') IS NOT NULL AS present",
+    );
+    if (!rows[0].present) {
+      // The branch came from production, so this table exists there. If it does
+      // not, the parent is not the database this release migrates and the whole
+      // rehearsal would be measuring the wrong thing.
+      throw new Error(
+        'The branched database has no `migrations` table. Check NEON_PARENT_BRANCH ' +
+          'points at the production database — see migrations/README.md.',
+      );
+    }
+    // `timestamp` is quoted because it is also a type name in Postgres, which
+    // makes the bare identifier ambiguous in some positions. TypeORM quotes it
+    // for the same reason.
+    const applied = await client.query('SELECT "timestamp" FROM migrations');
+    return new Set(applied.rows.map((row) => String(row.timestamp)));
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Never let the branch's connection string reach the log. It carries a
+ * password, and TypeORM's `logging: ['query','error','schema']` makes this
+ * script's output verbose enough that a leak would be easy to miss.
+ */
+function redact(text, uri) {
+  return text
+    .split(uri)
+    .join('postgresql://[redacted]')
+    .replace(/(postgres(?:ql)?:\/\/)[^:@\s]+:[^@\s]+@/g, '$1[redacted]:[redacted]@');
+}
+
+/**
+ * Run one npm script against the branch and return how it went.
+ *
+ * DATABASE_URL is passed explicitly, which is what makes this safe: per
+ * migrations/README.md, `dotenv` does not override an already-set variable, so
+ * the value here always wins over a local `.env` and these commands can never
+ * fall through to production.
+ */
+function runMigrationCommand(script, uri) {
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    const child = spawn('npm', ['run', script], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, DATABASE_URL: uri },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let output = '';
+    child.stdout.on('data', (chunk) => {
+      output += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      output += chunk;
+    });
+
+    child.on('error', (error) => {
+      resolve({ ok: false, ms: Date.now() - startedAt, output: String(error.message) });
+    });
+    child.on('close', (code) => {
+      resolve({
+        ok: code === 0,
+        code,
+        ms: Date.now() - startedAt,
+        output: redact(output, uri),
+      });
+    });
+  });
+}
+
+function seconds(ms) {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+const phases = [];
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+const branchName = `${PREFIX}${stamp}`;
+const keepBranch = process.env.REHEARSAL_KEEP_BRANCH?.trim() === '1';
+let branchId;
+let uri;
+
+/**
+ * Run a phase, record its timing, and stop the rehearsal if it fails.
+ * Returns false when the caller should stop.
+ */
+async function phase(title, script) {
+  console.log(`\n--- ${title} ---`);
+  const result = await runMigrationCommand(script, uri);
+  phases.push({ title, ok: result.ok, ms: result.ms });
+  console.log(result.output.trimEnd());
+
+  if (result.ok) {
+    console.log(`  OK in ${seconds(result.ms)}`);
+    return true;
+  }
+
+  console.error(`::error::${title} failed (exit ${result.code}) after ${seconds(result.ms)}.`);
+  process.exitCode = 1;
+  return false;
+}
+
+try {
+  // ------------------------------------------------------------- branch ----
+  const { branches = [] } = await neon('/branches');
+
+  // Neon renamed `primary` to `default`; accept either, as
+  // create-restore-point.mjs does.
+  const parentName = process.env.NEON_PARENT_BRANCH?.trim();
+  const parent = parentName
+    ? branches.find((branch) => branch.name === parentName)
+    : branches.find((branch) => branch.default === true || branch.primary === true);
+
+  if (!parent) {
+    throw new Error(
+      parentName
+        ? `Branch "${parentName}" does not exist in project ${projectId}.`
+        : `Could not identify the default branch of project ${projectId}. Set NEON_PARENT_BRANCH explicitly.`,
+    );
+  }
+
+  console.log(`Branching "${parent.name}" (${parent.id}) as "${branchName}"...`);
+
+  // A read_write endpoint, unlike create-restore-point.mjs: a restore point is
+  // storage-only because nothing connects to it, whereas this branch exists
+  // precisely to be migrated. The endpoint is deleted with the branch below.
+  const t0 = Date.now();
+  const created = await neon('/branches', {
+    method: 'POST',
+    body: {
+      branch: { name: branchName, parent_id: parent.id },
+      endpoints: [{ type: 'read_write' }],
+    },
+  });
+  branchId = created?.branch?.id;
+  if (!branchId) {
+    throw new Error(
+      `Neon accepted the request but returned no branch id: ${JSON.stringify(created).slice(0, 300)}`,
+    );
+  }
+  const branchMs = Date.now() - t0;
+  console.log(`  branch ready in ${seconds(branchMs)}  (${branchId})`);
+
+  uri =
+    created.connection_uris?.[0]?.connection_uri ||
+    (
+      await neon(
+        `/branches/${encodeURIComponent(branchId)}/connection_uri?database_name=neondb&role_name=neondb_owner`,
+      )
+    )?.uri;
+  if (!uri) {
+    throw new Error(
+      'Neon did not return a connection URI for the branch. The branch exists — ' +
+        'inspect it in the console before deleting.',
+    );
+  }
+
+  // ------------------------------------------------------------ pending ----
+  const onDisk = migrationsOnDisk();
+  const applied = await appliedTimestamps(uri);
+  const pending = onDisk.filter((migration) => !applied.has(migration.timestamp));
+
+  console.log(
+    `\n${onDisk.length} migration(s) on disk, ${applied.size} applied to production, ` +
+      `${pending.length} pending.`,
+  );
+
+  if (pending.length === 0) {
+    // The common case. Most releases change no schema, and a rehearsal with
+    // nothing to rehearse must not look like a pass that proved something.
+    console.log('\nThis release adds no migrations. Nothing to rehearse.');
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      appendFileSync(
+        process.env.GITHUB_STEP_SUMMARY,
+        '### Migration rehearsal\n\nThis release adds no migrations — nothing to rehearse.\n',
+      );
+    }
+  } else {
+    for (const migration of pending) {
+      console.log(`  pending: ${migration.name}`);
+    }
+
+    const blocked = pending.filter((migration) => IRREVERSIBLE.has(migration.name));
+
+    // ------------------------------------------------------------ forward ----
+    let advanced = await phase(
+      `Forward: applying ${pending.length} migration(s) to real data`,
+      'migration:run',
+    );
+
+    // Prove the forward run actually recorded what it claimed, rather than
+    // exiting 0 having skipped the pending set.
+    if (advanced) {
+      const after = await appliedTimestamps(uri);
+      const missing = pending.filter((migration) => !after.has(migration.timestamp));
+      if (missing.length > 0) {
+        console.error(
+          `::error::migration:run exited 0 but did not record: ${missing.map((m) => m.name).join(', ')}`,
+        );
+        process.exitCode = 1;
+        advanced = false;
+      } else {
+        console.log(`  all ${pending.length} migration(s) recorded in the migrations table`);
+      }
+    }
+
+    // ------------------------------------------------------------ reverse ----
+    if (advanced && blocked.length > 0) {
+      // Not a failure. These are a deliberate design decision, documented in
+      // migrations.spec.ts and asserted there.
+      console.log(
+        `\n--- Reverse: skipped ---\n  ${blocked
+          .map((m) => m.name)
+          .join(', ')} is intentionally irreversible, so reverting past it would ` +
+          'prove nothing. Forward path above is still verified.',
+      );
+      phases.push({ title: 'Reverse: skipped (irreversible migration in release)', ok: true, ms: 0 });
+    } else if (advanced) {
+      for (let i = pending.length; i >= 1; i -= 1) {
+        const target = pending[i - 1];
+        if (!(await phase(`Reverse: reverting ${target.name}`, 'migration:revert'))) {
+          advanced = false;
+          break;
+        }
+      }
+
+      // ----------------------------------------------------------- redo ----
+      // Revert, fix, redeploy is the sequence RUNBOOK §5 actually prescribes,
+      // and a migration can be reversible once without being re-appliable —
+      // a `down()` that drops a column but leaves its index behind fails the
+      // second `up()`, and nothing before this step would catch it.
+      if (advanced) {
+        await phase('Re-apply: running the forward path a second time', 'migration:run');
+      }
+    }
+  }
+
+  // ------------------------------------------------------------ summary ----
+  if (phases.length > 0) {
+    console.log('\n--- migration rehearsal ---');
+    for (const entry of phases) {
+      console.log(`  ${entry.ok ? 'ok  ' : 'FAIL'}  ${seconds(entry.ms).padStart(7)}  ${entry.title}`);
+    }
+    const total = phases.reduce((sum, entry) => sum + entry.ms, 0);
+    console.log(`  ${' '.repeat(4)}  ${seconds(total).padStart(7)}  TOTAL`);
+
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      const lines = [
+        '### Migration rehearsal',
+        '',
+        `Rehearsed against a copy-on-write branch of \`${parent.name}\`.`,
+        '',
+        '| Phase | Result | Time |',
+        '| --- | --- | --- |',
+        ...phases.map(
+          (entry) => `| ${entry.title} | ${entry.ok ? 'pass' : '**FAIL**'} | ${seconds(entry.ms)} |`,
+        ),
+        '',
+        `Total ${seconds(total)}. Production was not touched.`,
+        '',
+      ];
+      appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
+    }
+  }
+
+  if (process.exitCode === 1) {
+    console.error(
+      '\nThis release must not migrate production. The failure above would have ' +
+        'happened in the `migrate` job, against live data.',
+    );
+  } else if (phases.length > 0) {
+    console.log('\nRehearsal passed. These migrations apply to production-shaped data.');
+  }
+  // No `else`: a release with no pending migrations already said so, and must
+  // not print a pass line claiming migrations were verified against real data.
+} finally {
+  // Always clean up. A rehearsal that leaks branches hits Neon's per-project
+  // branch limit and starts failing every release.
+  if (branchId && !keepBranch) {
+    try {
+      await neon(`/branches/${encodeURIComponent(branchId)}`, { method: 'DELETE' });
+      console.log(`\nDeleted rehearsal branch ${branchName} (${branchId})`);
+    } catch (error) {
+      console.error(
+        `\n::warning::Could not delete rehearsal branch ${branchId} ` +
+          `(${error instanceof Error ? error.message : error}). Delete it manually — ` +
+          `it is named ${branchName}.`,
+      );
+    }
+  } else if (branchId) {
+    console.log(
+      `\nKept rehearsal branch ${branchName} (${branchId}) — REHEARSAL_KEEP_BRANCH=1. ` +
+        'Delete it when you are done; it counts against the project branch limit.',
+    );
+  }
+}

--- a/scripts/ci/migration-rehearsal.mjs
+++ b/scripts/ci/migration-rehearsal.mjs
@@ -402,10 +402,20 @@ try {
     console.log(`  ${' '.repeat(4)}  ${seconds(total).padStart(7)}  TOTAL`);
 
     if (process.env.GITHUB_STEP_SUMMARY) {
+      // Named from our own configuration rather than from `parent.name`, which
+      // arrived in a Neon API response. Writing HTTP response data to a file is
+      // a real taint flow (CodeQL js/http-to-file-access), and a branch name
+      // this script did not choose would also be free to inject markdown into
+      // the job summary. When NEON_PARENT_BRANCH is set the two are identical
+      // by construction — the branch is looked up *by* that name above.
+      const parentLabel = process.env.NEON_PARENT_BRANCH?.trim()
+        ? `\`${process.env.NEON_PARENT_BRANCH.trim()}\``
+        : 'the production default branch';
+
       const lines = [
         '### Migration rehearsal',
         '',
-        `Rehearsed against a copy-on-write branch of \`${parent.name}\`.`,
+        `Rehearsed against a copy-on-write branch of ${parentLabel}.`,
         '',
         '| Phase | Result | Time |',
         '| --- | --- | --- |',


### PR DESCRIPTION
…on rehearsal

Introduces a new command `db:rehearse` to apply, revert, and reapply pending migrations on a temporary branch of production data. This helps ensure migrations are safe before applying them to the live database. Additionally, updates the CI workflow to include a migration rehearsal step that runs on pushes to the main branch, enhancing the safety of database migrations.