### PR TITLE
style(user-service): wrap the sort order union so lint:check passes

### DIFF
--- a/apps/user-service/src/services/employee-services/search-employee.service.ts
+++ b/apps/user-service/src/services/employee-services/search-employee.service.ts
@@ -178,7 +178,8 @@ export class SearchEmployeeService implements ISearchEmployeeService {
         ];
         const field = validSortFields.includes(sortBy) ? sortBy : 'createdAt';
         const order = (sortOrder?.toUpperCase() === 'ASC' ? 'ASC' : 'DESC') as
-          'ASC' | 'DESC';
+          | 'ASC'
+          | 'DESC';
 
         if (field === 'yearsOfExperience') {
           qb.orderBy(


### PR DESCRIPTION
`main` has been failing its own `lint:check` gate: prettier wants the 'ASC' | 'DESC' assertion broken across lines, and eslint runs prettier/prettier as an error. The `lint` job is a `needs` of `test`, `build` and everything downstream, so every push to main stopped at the first job and no release could reach `migrate` or `deploy`.

Machine-generated by `eslint --fix`. Whitespace inside a type annotation — no behaviour change. Verified with a full `lint:check` (exit 0) and `tsc --noEmit -p tsconfig.json` (exit 0).