### PR TITLE
chore: point nest-cli root at a directory that exists

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -8,7 +8,7 @@
     "tsConfigPath": "apps/api-gateway/tsconfig.app.json"
   },
   "monorepo": true,
-  "root": "apps/AparaTalent",
+  "root": "apps/api-gateway",
   "projects": {
     "api-gateway": {
       "type": "application",


### PR DESCRIPTION
#82 removed the scaffolding residue from nest-cli.json but left the
top-level `root` on "apps/AparaTalent" — a directory this repository has
never contained. Its siblings `sourceRoot` and `compilerOptions.
tsConfigPath` were both moved to api-gateway in that change; this is the
third key of the same group.

Harmless at runtime — in monorepo mode the per-project `root` entries
are what the builder uses — which is exactly why it survived: nothing
fails, it just sends the next person looking for a path that is not
there.

`AparaTalent` now appears nowhere in the repository outside
package-lock.json. Verified with `npm run build:all` (exit 0), the same
command the build job runs.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
