### PR TITLE
refactor(migrations): one source of truth for irreversible migrations

### DIFF
--- a/migrations/irreversible.json
+++ b/migrations/irreversible.json
@@ -1,0 +1,5 @@
+{
+  "$comment": "Migrations whose down() is deliberately a no-op. Keyed by TypeORM class name; the value is why. Read by migrations.spec.ts (which skips the rollback-SQL contract for these) and by scripts/ci/migration-rehearsal.mjs (which skips its reverse phase when a release contains one). Adding a migration here is a decision that its rollback is impossible or unsafe, not a way to silence a failing test.",
+  "NormalizeExperienceLevels1781136000000": "The original free-text experience levels are gone once normalized. There is nothing left to restore them from.",
+  "HashRefreshTokens1784073600000": "Reversing this would write bearer credentials back in plaintext, which is the vulnerability the migration exists to remove."
+}

--- a/migrations/migrations.spec.ts
+++ b/migrations/migrations.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { AddChatAudio1773705600000 } from './1773705600000-AddChatAudio';
 import { AddNotifications1773705601000 } from './1773705601000-AddNotifications';
 import { AddPgvectorCareerScope1778889600000 } from './1778889600000-AddPgvectorCareerScope';
@@ -9,6 +11,13 @@ import { AddExperienceCompany1783987200000 } from './1783987200000-AddExperience
 import { AddResumeTemplateKey1783987201000 } from './1783987201000-AddResumeTemplateKey';
 import { HashRefreshTokens1784073600000 } from './1784073600000-HashRefreshTokens';
 import { AddJobSearchColumns1785316800000 } from './1785316800000-AddJobSearchColumns';
+
+// Read rather than imported: the tsconfig does not enable resolveJsonModule,
+// and reading it the same way scripts/ci/migration-rehearsal.mjs does keeps
+// the two consumers honest about sharing one file.
+const irreversible: Record<string, string> = JSON.parse(
+  readFileSync(join(__dirname, 'irreversible.json'), 'utf8'),
+);
 
 describe('database migration contracts', () => {
   const migrations = [
@@ -38,9 +47,30 @@ describe('database migration contracts', () => {
     },
   );
 
-  const irreversible = ['experience normalization', 'hash refresh tokens'];
+  // Keyed by class name, so this reads the same list the rehearsal script
+  // reads — `constructor.name` avoids inventing a third naming scheme
+  // alongside the file names and the friendly labels above.
+  const isIrreversible = (migration: object) =>
+    Object.prototype.hasOwnProperty.call(
+      irreversible,
+      migration.constructor.name,
+    );
 
-  it.each(migrations.filter(([name]) => !irreversible.includes(name)))(
+  // Without this the list rots silently: a renamed or deleted migration would
+  // leave a key matching nothing, and its rollback would quietly start being
+  // skipped by both consumers for a migration that no longer exists.
+  it('lists only real migrations as irreversible', () => {
+    const known = new Set(migrations.map(([, m]) => m.constructor.name));
+    const declared = Object.keys(irreversible).filter(
+      (key) => !key.startsWith('$'),
+    );
+    expect(declared.length).toBeGreaterThan(0);
+    for (const name of declared) {
+      expect(known).toContain(name);
+    }
+  });
+
+  it.each(migrations.filter(([, migration]) => !isIrreversible(migration)))(
     '%s migration provides executable rollback SQL',
     async (_name, migration) => {
       const query = jest.fn().mockResolvedValue(undefined);

--- a/scripts/ci/migration-rehearsal.mjs
+++ b/scripts/ci/migration-rehearsal.mjs
@@ -41,8 +41,7 @@
  *   REHEARSAL_KEEP_BRANCH           set to 1 to leave the branch for inspection
  */
 import { spawn } from 'node:child_process';
-import { readdirSync } from 'node:fs';
-import { appendFileSync } from 'node:fs';
+import { appendFileSync, readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { Client } from 'pg';
 
@@ -57,18 +56,16 @@ const PREFIX = 'ci-migration-rehearsal/';
 // Migrations whose `down()` is deliberately a no-op, so reverting past them
 // proves nothing and the revert phase is skipped when one is in this release.
 //
-// This list is the second copy of the one in `migrations/migrations.spec.ts`
-// (`irreversible`), which names them in prose. Keep the two in step; better
-// still, give the migration classes a static marker both can read.
-//
-//   NormalizeExperienceLevels — the original free-text experience levels are
-//     gone once normalized; there is nothing to restore them from.
-//   HashRefreshTokens         — reversing it would write bearer credentials
-//     back in plaintext, which is the vulnerability it exists to remove.
-const IRREVERSIBLE = new Set([
-  'NormalizeExperienceLevels1781136000000',
-  'HashRefreshTokens1784073600000',
-]);
+// Single source of truth, shared with `migrations/migrations.spec.ts` — which
+// skips the rollback-SQL contract for the same entries, and asserts every key
+// names a migration that exists. `$comment` is documentation, not a class.
+const IRREVERSIBLE = new Set(
+  Object.keys(
+    JSON.parse(
+      readFileSync(new URL('../../migrations/irreversible.json', import.meta.url), 'utf8'),
+    ),
+  ).filter((key) => !key.startsWith('$')),
+);
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 const projectId = process.env.NEON_PROJECT_ID?.trim();


### PR DESCRIPTION
The list of migrations whose down() is a deliberate no-op existed twice:
as friendly names in migrations.spec.ts and as class names in
scripts/ci/migration-rehearsal.mjs. Two copies in two naming schemes,
with nothing to keep them in step — and the failure is silent in the
worst direction. Add a third irreversible migration, forget the script,
and the rehearsal tries to revert it, fails, and blocks a release for a
migration that was never meant to roll back.

migrations/irreversible.json now holds it once, keyed by class name with
the reason as the value. The spec keys off `constructor.name` rather
than its friendly labels, so no third naming scheme appears.

Also adds the test that makes the file self-maintaining: every key must
name a migration that actually exists. Verified it fails as intended by
adding a bogus entry (1 failed, 24 passed) and passes once removed
(25 passed) — without it a renamed migration would leave a key matching
nothing and its rollback would quietly stop being checked.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
