### PR TITLE
Infrastructure hardening: pin actions, lint the release scripts, two cleanups

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,10 +40,10 @@ jobs:
       matrix:
         language: [javascript-typescript, actions]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
           # `security-extended` over the default set. Dial back to `security`
@@ -51,6 +51,6 @@ jobs:
           queries: security-extended
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/db-recovery.yml
+++ b/.github/workflows/db-recovery.yml
@@ -52,10 +52,10 @@ jobs:
       S3_BACKUP_ACCESS_KEY_ID: ${{ secrets.S3_BACKUP_ACCESS_KEY_ID }}
       S3_BACKUP_SECRET_ACCESS_KEY: ${{ secrets.S3_BACKUP_SECRET_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -104,10 +104,10 @@ jobs:
       NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
       NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Reject committed environment files
         shell: bash
@@ -54,10 +54,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload dependency audit
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: api-dependency-audit
           path: dependency-audit.json
@@ -82,10 +82,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -105,10 +105,10 @@ jobs:
     timeout-minutes: 35
     needs: [secrets, dependencies, lint]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: api-coverage
           path: coverage/
@@ -137,10 +137,10 @@ jobs:
     timeout-minutes: 25
     needs: [secrets, dependencies, lint, test]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -183,7 +183,7 @@ jobs:
           - job-service
           - notification-service
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Tagged with the commit SHA and pushed on main, so the artifact that was
       # built, scanned and (soon) deployed is one immutable thing rather than
@@ -221,7 +221,7 @@ jobs:
 
       - name: Upload scan results
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: trivy-${{ matrix.service }}.sarif
           category: container-${{ matrix.service }}
@@ -249,7 +249,7 @@ jobs:
     timeout-minutes: 15
     needs: [secrets, dependencies, lint]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate Grafana dashboard JSON
         run: jq empty monitoring/grafana/dashboards/apsaratalent-api.json
@@ -330,7 +330,7 @@ jobs:
       matrix:
         service: [prometheus, alertmanager, blackbox, grafana]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build production monitoring container
         run: >-
@@ -361,7 +361,7 @@ jobs:
 
       - name: Upload scan results
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: trivy-monitoring-${{ matrix.service }}.sarif
           category: monitoring-${{ matrix.service }}
@@ -410,10 +410,10 @@ jobs:
     needs: [release-preflight]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -474,10 +474,10 @@ jobs:
     needs: [release-preflight, migration-rehearsal]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -538,7 +538,7 @@ jobs:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       PRODUCTION_API_URL: ${{ vars.PRODUCTION_API_URL }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Require deployment configuration
         shell: bash
@@ -553,7 +553,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/infra-drift.yml
+++ b/.github/workflows/infra-drift.yml
@@ -35,10 +35,10 @@ jobs:
       NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
       NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -48,10 +48,10 @@ jobs:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       PRODUCTION_API_URL: ${{ vars.PRODUCTION_API_URL }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/storage-backup.yml
+++ b/.github/workflows/storage-backup.yml
@@ -37,10 +37,10 @@ jobs:
       S3_BACKUP_ACCESS_KEY_ID: ${{ secrets.S3_BACKUP_ACCESS_KEY_ID }}
       S3_BACKUP_SECRET_ACCESS_KEY: ${{ secrets.S3_BACKUP_SECRET_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,13 +1,18 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import js from '@eslint/js';
 import { FlatCompat } from '@eslint/eslintrc';
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 const compat = new FlatCompat({ baseDirectory: currentDirectory });
 
-export default [
-  { ignores: ['dist/**', 'coverage/**', 'node_modules/**'] },
-  ...compat.config({
+// The typed rules need `parserOptions.project`, so they can only apply to
+// files the tsconfig actually includes. Without this `files` scope every
+// .mjs script fails to parse — which is why they were excluded from
+// `lint:check` entirely, leaving a meaningful amount of release behaviour
+// (the deploy, rollback, backup and migration-rehearsal scripts) unchecked.
+const typescript = compat
+  .config({
     parser: '@typescript-eslint/parser',
     parserOptions: {
       project: 'tsconfig.json',
@@ -36,5 +41,33 @@ export default [
         },
       ],
     },
-  }),
+  })
+  .map((config) => ({ ...config, files: ['**/*.ts'] }));
+
+// Plain ESM, parsed by the default parser. These scripts are not TypeScript
+// and are not in any tsconfig project, so they get formatting and the
+// untyped correctness rules only — which is still strictly more than the
+// nothing they had before.
+const nodeScripts = [
+  { ...js.configs.recommended, files: ['**/*.mjs'] },
+  ...compat
+    .config({
+      parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+      plugins: ['unused-imports'],
+      extends: ['plugin:prettier/recommended'],
+      env: { node: true, es2024: true },
+      rules: {
+        'unused-imports/no-unused-imports': 'error',
+        // A deliberately empty catch is a real pattern in these scripts:
+        // cleanup that must never mask the error it is cleaning up after.
+        'no-empty': ['error', { allowEmptyCatch: true }],
+      },
+    })
+    .map((config) => ({ ...config, files: ['**/*.mjs'] })),
+];
+
+export default [
+  { ignores: ['dist/**', 'coverage/**', 'node_modules/**'] },
+  ...typescript,
+  ...nodeScripts,
 ];

--- a/migrations/irreversible.json
+++ b/migrations/irreversible.json
@@ -1,0 +1,5 @@
+{
+  "$comment": "Migrations whose down() is deliberately a no-op. Keyed by TypeORM class name; the value is why. Read by migrations.spec.ts (which skips the rollback-SQL contract for these) and by scripts/ci/migration-rehearsal.mjs (which skips its reverse phase when a release contains one). Adding a migration here is a decision that its rollback is impossible or unsafe, not a way to silence a failing test.",
+  "NormalizeExperienceLevels1781136000000": "The original free-text experience levels are gone once normalized. There is nothing left to restore them from.",
+  "HashRefreshTokens1784073600000": "Reversing this would write bearer credentials back in plaintext, which is the vulnerability the migration exists to remove."
+}

--- a/migrations/migrations.spec.ts
+++ b/migrations/migrations.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { AddChatAudio1773705600000 } from './1773705600000-AddChatAudio';
 import { AddNotifications1773705601000 } from './1773705601000-AddNotifications';
 import { AddPgvectorCareerScope1778889600000 } from './1778889600000-AddPgvectorCareerScope';
@@ -9,6 +11,13 @@ import { AddExperienceCompany1783987200000 } from './1783987200000-AddExperience
 import { AddResumeTemplateKey1783987201000 } from './1783987201000-AddResumeTemplateKey';
 import { HashRefreshTokens1784073600000 } from './1784073600000-HashRefreshTokens';
 import { AddJobSearchColumns1785316800000 } from './1785316800000-AddJobSearchColumns';
+
+// Read rather than imported: the tsconfig does not enable resolveJsonModule,
+// and reading it the same way scripts/ci/migration-rehearsal.mjs does keeps
+// the two consumers honest about sharing one file.
+const irreversible: Record<string, string> = JSON.parse(
+  readFileSync(join(__dirname, 'irreversible.json'), 'utf8'),
+);
 
 describe('database migration contracts', () => {
   const migrations = [
@@ -38,9 +47,30 @@ describe('database migration contracts', () => {
     },
   );
 
-  const irreversible = ['experience normalization', 'hash refresh tokens'];
+  // Keyed by class name, so this reads the same list the rehearsal script
+  // reads — `constructor.name` avoids inventing a third naming scheme
+  // alongside the file names and the friendly labels above.
+  const isIrreversible = (migration: object) =>
+    Object.prototype.hasOwnProperty.call(
+      irreversible,
+      migration.constructor.name,
+    );
 
-  it.each(migrations.filter(([name]) => !irreversible.includes(name)))(
+  // Without this the list rots silently: a renamed or deleted migration would
+  // leave a key matching nothing, and its rollback would quietly start being
+  // skipped by both consumers for a migration that no longer exists.
+  it('lists only real migrations as irreversible', () => {
+    const known = new Set(migrations.map(([, m]) => m.constructor.name));
+    const declared = Object.keys(irreversible).filter(
+      (key) => !key.startsWith('$'),
+    );
+    expect(declared.length).toBeGreaterThan(0);
+    for (const name of declared) {
+      expect(known).toContain(name);
+    }
+  });
+
+  it.each(migrations.filter(([, migration]) => !isIrreversible(migration)))(
     '%s migration provides executable rollback SQL',
     async (_name, migration) => {
       const query = jest.fn().mockResolvedValue(undefined);

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -8,7 +8,7 @@
     "tsConfigPath": "apps/api-gateway/tsconfig.app.json"
   },
   "monorepo": true,
-  "root": "apps/AparaTalent",
+  "root": "apps/api-gateway",
   "projects": {
     "api-gateway": {
       "type": "application",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start:prod": "npm run start:production",
     "start:prod:api": "cross-env NODE_ENV=production node --enable-source-maps dist/apps/api-gateway/main.js",
     "lint": "npm run lint:check -- --fix",
-    "lint:check": "eslint \"apps/**/*.ts\" \"libs/**/*.ts\" \"test/**/*.ts\" \"migrations/**/*.ts\" \"scripts/**/*.ts\" \"data-source.ts\"",
+    "lint:check": "eslint \"apps/**/*.ts\" \"libs/**/*.ts\" \"test/**/*.ts\" \"migrations/**/*.ts\" \"scripts/**/*.ts\" \"scripts/**/*.mjs\" \"test/**/*.mjs\" \"data-source.ts\"",
     "test": "cross-env NODE_ENV=test jest",
     "test:ci": "cross-env NODE_ENV=test jest --runInBand",
     "test:watch": "jest --watch",

--- a/scripts/ci/backup-storage.mjs
+++ b/scripts/ci/backup-storage.mjs
@@ -59,8 +59,12 @@ const missing = [
 if (missing.length > 0) {
   // Loud, not fatal-by-accident: a missing backup is a real problem, but it
   // should read as "not configured yet", not as a mysterious crash.
-  console.error(`Storage backup is not configured. Missing: ${missing.join(', ')}`);
-  console.error('See docs/STORAGE.md — "Backups" — for how to create the bucket and token.');
+  console.error(
+    `Storage backup is not configured. Missing: ${missing.join(', ')}`,
+  );
+  console.error(
+    'See docs/STORAGE.md — "Backups" — for how to create the bucket and token.',
+  );
   process.exit(1);
 }
 
@@ -109,7 +113,9 @@ const pending = [...live.entries()].filter(
 if (pending.length === 0) {
   console.log('\nBackup is already current. Nothing to copy.');
 } else {
-  console.log(`\n${dryRun ? 'would copy' : 'copying'} ${pending.length} object(s):`);
+  console.log(
+    `\n${dryRun ? 'would copy' : 'copying'} ${pending.length} object(s):`,
+  );
   let copied = 0;
   const failures = [];
   for (const [key] of pending) {
@@ -148,7 +154,11 @@ if (pending.length === 0) {
       // nothing at all. Found on 2026-08-08 with a token issued as "Object Read
       // only". A backup that lies about succeeding is worse than no backup,
       // because it stops anyone looking.
-      if (/AccessDenied|Unauthorized|InvalidAccessKeyId|SignatureDoesNotMatch/i.test(name)) {
+      if (
+        /AccessDenied|Unauthorized|InvalidAccessKeyId|SignatureDoesNotMatch/i.test(
+          name,
+        )
+      ) {
         failures.push(
           `${key}: ${name} — the backup token cannot write to ${backupBucket}. ` +
             'It needs Object Read & Write, not Read only.',

--- a/scripts/ci/check-infra-drift.mjs
+++ b/scripts/ci/check-infra-drift.mjs
@@ -98,7 +98,9 @@ for (const service of MUST_BE_PUBLIC) {
 const fingerprint = (value) =>
   createHash('sha256').update(value).digest('hex').slice(0, 8);
 
-const prometheusToken = (readVariables('prometheus').METRICS_TOKEN || '').trim();
+const prometheusToken = (
+  readVariables('prometheus').METRICS_TOKEN || ''
+).trim();
 if (!prometheusToken) {
   failures.push(
     'prometheus is missing METRICS_TOKEN — it cannot authenticate to any /metrics endpoint.',
@@ -182,7 +184,9 @@ if (neonKey && neonProject) {
     );
   }
 } else {
-  notes.push('neon: retention not checked — NEON_API_KEY/NEON_PROJECT_ID unset');
+  notes.push(
+    'neon: retention not checked — NEON_API_KEY/NEON_PROJECT_ID unset',
+  );
 }
 
 for (const note of notes) console.log(`  ${note}`);

--- a/scripts/ci/create-restore-point.mjs
+++ b/scripts/ci/create-restore-point.mjs
@@ -24,7 +24,8 @@
  *                             so later steps can reference the restore point.
  */
 
-const API_BASE = process.env.NEON_API_BASE || 'https://console.neon.tech/api/v2';
+const API_BASE =
+  process.env.NEON_API_BASE || 'https://console.neon.tech/api/v2';
 
 // Reserved namespace. Pruning only ever considers branches under this prefix,
 // so a human-created branch can never be deleted by this script.
@@ -45,7 +46,9 @@ if (!apiKey || !projectId) {
 const keepRaw = process.env.RESTORE_POINT_KEEP?.trim() || '10';
 const keep = Number.parseInt(keepRaw, 10);
 if (!Number.isInteger(keep) || keep < 0) {
-  throw new Error(`RESTORE_POINT_KEEP must be a non-negative integer, got "${keepRaw}".`);
+  throw new Error(
+    `RESTORE_POINT_KEEP must be a non-negative integer, got "${keepRaw}".`,
+  );
 }
 
 /**
@@ -89,13 +92,18 @@ async function neon(path, { method = 'GET', body } = {}) {
       );
     }
     if (response.status === 404) {
-      throw new Error(`Neon project "${projectId}" not found (HTTP 404). Check NEON_PROJECT_ID.`);
+      throw new Error(
+        `Neon project "${projectId}" not found (HTTP 404). Check NEON_PROJECT_ID.`,
+      );
     }
 
     const detail = (await response.text()).slice(0, 500);
     lastError = `HTTP ${response.status}: ${detail}`;
 
-    const retryable = response.status === 423 || response.status === 429 || response.status >= 500;
+    const retryable =
+      response.status === 423 ||
+      response.status === 429 ||
+      response.status >= 500;
     if (!retryable) break;
 
     await new Promise((resolve) => setTimeout(resolve, attempt * 3_000));
@@ -111,7 +119,9 @@ const { branches = [] } = await neon('/branches');
 const parentName = process.env.NEON_PARENT_BRANCH?.trim();
 const parent = parentName
   ? branches.find((branch) => branch.name === parentName)
-  : branches.find((branch) => branch.default === true || branch.primary === true);
+  : branches.find(
+      (branch) => branch.default === true || branch.primary === true,
+    );
 
 if (!parent) {
   throw new Error(
@@ -121,11 +131,20 @@ if (!parent) {
   );
 }
 
-const label = (process.env.RESTORE_POINT_LABEL || process.env.GITHUB_SHA || 'manual').slice(0, 12);
-const stamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, 'Z');
+const label = (
+  process.env.RESTORE_POINT_LABEL ||
+  process.env.GITHUB_SHA ||
+  'manual'
+).slice(0, 12);
+const stamp = new Date()
+  .toISOString()
+  .replace(/[-:]/g, '')
+  .replace(/\.\d+Z$/, 'Z');
 const name = `${PREFIX}${stamp}-${label}`;
 
-console.log(`Creating restore point "${name}" from "${parent.name}" (${parent.id})...`);
+console.log(
+  `Creating restore point "${name}" from "${parent.name}" (${parent.id})...`,
+);
 
 // No `endpoints` — a storage-only branch. Nothing connects to a restore point
 // until someone deliberately attaches a compute during recovery, and computes
@@ -137,15 +156,22 @@ const created = await neon('/branches', {
 
 const branchId = created?.branch?.id;
 if (!branchId) {
-  throw new Error(`Neon accepted the request but returned no branch id: ${JSON.stringify(created).slice(0, 300)}`);
+  throw new Error(
+    `Neon accepted the request but returned no branch id: ${JSON.stringify(created).slice(0, 300)}`,
+  );
 }
 
 console.log(`Restore point ready: ${name} (${branchId})`);
-console.log(`Recover with: neon branches restore ${parent.name} ${branchId}  # or use the Neon console`);
+console.log(
+  `Recover with: neon branches restore ${parent.name} ${branchId}  # or use the Neon console`,
+);
 
 if (process.env.GITHUB_OUTPUT) {
   const { appendFileSync } = await import('node:fs');
-  appendFileSync(process.env.GITHUB_OUTPUT, `branch-id=${branchId}\nbranch-name=${name}\n`);
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    `branch-id=${branchId}\nbranch-name=${name}\n`,
+  );
 }
 
 // Neon enforces a per-project branch limit. Without pruning, this script would
@@ -159,22 +185,31 @@ if (keep === 0) {
 const { branches: current = [] } = await neon('/branches');
 const ours = current
   .filter((branch) => branch.name.startsWith(PREFIX) && branch.id !== branchId)
-  .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+  .sort(
+    (a, b) =>
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
 
 // `keep` counts the restore point we just made, so retain keep-1 older ones.
 const stale = ours.slice(Math.max(keep - 1, 0));
 if (stale.length === 0) {
-  console.log(`Retention satisfied: ${ours.length + 1} restore point(s), keeping ${keep}.`);
+  console.log(
+    `Retention satisfied: ${ours.length + 1} restore point(s), keeping ${keep}.`,
+  );
   process.exit(0);
 }
 
 for (const branch of stale) {
   try {
-    await neon(`/branches/${encodeURIComponent(branch.id)}`, { method: 'DELETE' });
+    await neon(`/branches/${encodeURIComponent(branch.id)}`, {
+      method: 'DELETE',
+    });
     console.log(`Pruned old restore point ${branch.name} (${branch.id})`);
   } catch (error) {
     // A restore point we could not delete is not a reason to block a release.
     // The next run retries, and the branch limit is not yet reached.
-    console.warn(`Could not prune ${branch.name}: ${error instanceof Error ? error.message : error}`);
+    console.warn(
+      `Could not prune ${branch.name}: ${error instanceof Error ? error.message : error}`,
+    );
   }
 }

--- a/scripts/ci/create-restore-point.mjs
+++ b/scripts/ci/create-restore-point.mjs
@@ -167,10 +167,30 @@ console.log(
 );
 
 if (process.env.GITHUB_OUTPUT) {
+  // `$GITHUB_OUTPUT` is parsed line by line as `key=value`, so a value
+  // containing a newline does not write a newline — it writes a new OUTPUT.
+  // `branchId` arrives in a Neon API response, which makes this the one place
+  // in this script where remote data reaches a file that later becomes
+  // workflow state (CodeQL js/http-to-file-access).
+  //
+  // Neon ids and this script's own branch names are single-line tokens, so
+  // anything else means the control plane returned something unexpected and
+  // the release should stop rather than write it.
+  const assertSingleLineToken = (label, value) => {
+    if (!/^[A-Za-z0-9._/-]+$/.test(value)) {
+      throw new Error(
+        `Refusing to write ${label} to GITHUB_OUTPUT: expected a single-line ` +
+          `token, got ${JSON.stringify(String(value).slice(0, 80))}.`,
+      );
+    }
+    return value;
+  };
+
   const { appendFileSync } = await import('node:fs');
   appendFileSync(
     process.env.GITHUB_OUTPUT,
-    `branch-id=${branchId}\nbranch-name=${name}\n`,
+    `branch-id=${assertSingleLineToken('branch-id', branchId)}\n` +
+      `branch-name=${assertSingleLineToken('branch-name', name)}\n`,
   );
 }
 

--- a/scripts/ci/db-restore-drill.mjs
+++ b/scripts/ci/db-restore-drill.mjs
@@ -28,7 +28,8 @@
  */
 import { Client } from 'pg';
 
-const API_BASE = process.env.NEON_API_BASE || 'https://console.neon.tech/api/v2';
+const API_BASE =
+  process.env.NEON_API_BASE || 'https://console.neon.tech/api/v2';
 
 // Reserved namespace, mirroring create-restore-point.mjs. Cleanup only ever
 // considers branches under this prefix, so a human's branch is never at risk.
@@ -133,7 +134,7 @@ async function inspect(connectionString, label) {
       // TypeORM's table. Missing means the restore produced an empty database,
       // which is the failure mode that matters most and is easy to miss when
       // only counting rows.
-      "SELECT count(*)::int AS applied FROM migrations",
+      'SELECT count(*)::int AS applied FROM migrations',
     );
     return {
       label,
@@ -174,12 +175,17 @@ try {
   });
   branchId = created.branch?.id;
   timings.createBranchMs = Date.now() - t0;
-  console.log(`  branch created in ${(timings.createBranchMs / 1000).toFixed(1)}s  (${branchId})`);
+  console.log(
+    `  branch created in ${(timings.createBranchMs / 1000).toFixed(1)}s  (${branchId})`,
+  );
 
   const uri =
     created.connection_uris?.[0]?.connection_uri ||
-    (await neon(`/branches/${encodeURIComponent(branchId)}/connection_uri?database_name=neondb&role_name=neondb_owner`))
-      ?.uri;
+    (
+      await neon(
+        `/branches/${encodeURIComponent(branchId)}/connection_uri?database_name=neondb&role_name=neondb_owner`,
+      )
+    )?.uri;
   if (!uri) {
     throw new Error(
       'Neon did not return a connection URI for the restored branch. The branch ' +
@@ -196,11 +202,15 @@ try {
   console.log(
     `  restored: ${restored.tables.size} tables, ${restored.migrations} migrations applied, ${restored.size}`,
   );
-  console.log(`  connected in ${restored.connectedMs}ms, verified in ${(timings.verifyMs / 1000).toFixed(1)}s`);
+  console.log(
+    `  connected in ${restored.connectedMs}ms, verified in ${(timings.verifyMs / 1000).toFixed(1)}s`,
+  );
 
   const problems = [];
   if (restored.tables.size === 0) {
-    problems.push('restored branch has no tables — the restore produced an empty database');
+    problems.push(
+      'restored branch has no tables — the restore produced an empty database',
+    );
   }
   if (restored.migrations !== live.migrations) {
     problems.push(
@@ -216,13 +226,17 @@ try {
     // an earlier point in time, so it should be <= live, never wildly above.
     const restoredRows = restored.tables.get(table);
     if (liveRows > 0 && restoredRows === 0) {
-      problems.push(`table empty in restore but has ${liveRows} rows live: ${table}`);
+      problems.push(
+        `table empty in restore but has ${liveRows} rows live: ${table}`,
+      );
     }
   }
 
   console.log('\n--- restore drill ---');
   console.log(`  recovered to:     ${recoverTo}`);
-  console.log(`  branch created:   ${(timings.createBranchMs / 1000).toFixed(1)}s`);
+  console.log(
+    `  branch created:   ${(timings.createBranchMs / 1000).toFixed(1)}s`,
+  );
   console.log(`  connect + verify: ${(timings.verifyMs / 1000).toFixed(1)}s`);
   console.log(
     `  TOTAL:            ${((timings.createBranchMs + timings.verifyMs) / 1000).toFixed(1)}s  <-- this is your restore time`,
@@ -235,13 +249,17 @@ try {
     for (const p of problems) console.error(`  - ${p}`);
     process.exitCode = 1;
   } else {
-    console.log('\nRestore verified: schema and data are present and consistent with live.');
+    console.log(
+      '\nRestore verified: schema and data are present and consistent with live.',
+    );
   }
 } finally {
   // Always clean up. A drill that leaves branches behind stops being run.
   if (branchId) {
     try {
-      await neon(`/branches/${encodeURIComponent(branchId)}`, { method: 'DELETE' });
+      await neon(`/branches/${encodeURIComponent(branchId)}`, {
+        method: 'DELETE',
+      });
       console.log(`\nCleaned up drill branch ${branchId}`);
     } catch (error) {
       console.error(

--- a/scripts/ci/migration-rehearsal.mjs
+++ b/scripts/ci/migration-rehearsal.mjs
@@ -45,7 +45,8 @@ import { appendFileSync, readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { Client } from 'pg';
 
-const API_BASE = process.env.NEON_API_BASE || 'https://console.neon.tech/api/v2';
+const API_BASE =
+  process.env.NEON_API_BASE || 'https://console.neon.tech/api/v2';
 const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
 
 // Reserved namespace, mirroring create-restore-point.mjs and
@@ -62,7 +63,10 @@ const PREFIX = 'ci-migration-rehearsal/';
 const IRREVERSIBLE = new Set(
   Object.keys(
     JSON.parse(
-      readFileSync(new URL('../../migrations/irreversible.json', import.meta.url), 'utf8'),
+      readFileSync(
+        new URL('../../migrations/irreversible.json', import.meta.url),
+        'utf8',
+      ),
     ),
   ).filter((key) => !key.startsWith('$')),
 );
@@ -101,7 +105,11 @@ async function neon(path, { method = 'GET', body } = {}) {
     }
     // 423 Locked means another project operation is in flight; 429 and 5xx are
     // likewise transient. Same policy as create-restore-point.mjs.
-    if (response.status === 423 || response.status === 429 || response.status >= 500) {
+    if (
+      response.status === 423 ||
+      response.status === 429 ||
+      response.status >= 500
+    ) {
       lastError = `HTTP ${response.status}`;
       await new Promise((r) => setTimeout(r, attempt * 3_000));
       continue;
@@ -181,7 +189,10 @@ function redact(text, uri) {
   return text
     .split(uri)
     .join('postgresql://[redacted]')
-    .replace(/(postgres(?:ql)?:\/\/)[^:@\s]+:[^@\s]+@/g, '$1[redacted]:[redacted]@');
+    .replace(
+      /(postgres(?:ql)?:\/\/)[^:@\s]+:[^@\s]+@/g,
+      '$1[redacted]:[redacted]@',
+    );
 }
 
 /**
@@ -210,7 +221,11 @@ function runMigrationCommand(script, uri) {
     });
 
     child.on('error', (error) => {
-      resolve({ ok: false, ms: Date.now() - startedAt, output: String(error.message) });
+      resolve({
+        ok: false,
+        ms: Date.now() - startedAt,
+        output: String(error.message),
+      });
     });
     child.on('close', (code) => {
       resolve({
@@ -249,7 +264,9 @@ async function phase(title, script) {
     return true;
   }
 
-  console.error(`::error::${title} failed (exit ${result.code}) after ${seconds(result.ms)}.`);
+  console.error(
+    `::error::${title} failed (exit ${result.code}) after ${seconds(result.ms)}.`,
+  );
   process.exitCode = 1;
   return false;
 }
@@ -263,7 +280,9 @@ try {
   const parentName = process.env.NEON_PARENT_BRANCH?.trim();
   const parent = parentName
     ? branches.find((branch) => branch.name === parentName)
-    : branches.find((branch) => branch.default === true || branch.primary === true);
+    : branches.find(
+        (branch) => branch.default === true || branch.primary === true,
+      );
 
   if (!parent) {
     throw new Error(
@@ -273,7 +292,9 @@ try {
     );
   }
 
-  console.log(`Branching "${parent.name}" (${parent.id}) as "${branchName}"...`);
+  console.log(
+    `Branching "${parent.name}" (${parent.id}) as "${branchName}"...`,
+  );
 
   // A read_write endpoint, unlike create-restore-point.mjs: a restore point is
   // storage-only because nothing connects to it, whereas this branch exists
@@ -312,7 +333,9 @@ try {
   // ------------------------------------------------------------ pending ----
   const onDisk = migrationsOnDisk();
   const applied = await appliedTimestamps(uri);
-  const pending = onDisk.filter((migration) => !applied.has(migration.timestamp));
+  const pending = onDisk.filter(
+    (migration) => !applied.has(migration.timestamp),
+  );
 
   console.log(
     `\n${onDisk.length} migration(s) on disk, ${applied.size} applied to production, ` +
@@ -334,7 +357,9 @@ try {
       console.log(`  pending: ${migration.name}`);
     }
 
-    const blocked = pending.filter((migration) => IRREVERSIBLE.has(migration.name));
+    const blocked = pending.filter((migration) =>
+      IRREVERSIBLE.has(migration.name),
+    );
 
     // ------------------------------------------------------------ forward ----
     let advanced = await phase(
@@ -346,7 +371,9 @@ try {
     // exiting 0 having skipped the pending set.
     if (advanced) {
       const after = await appliedTimestamps(uri);
-      const missing = pending.filter((migration) => !after.has(migration.timestamp));
+      const missing = pending.filter(
+        (migration) => !after.has(migration.timestamp),
+      );
       if (missing.length > 0) {
         console.error(
           `::error::migration:run exited 0 but did not record: ${missing.map((m) => m.name).join(', ')}`,
@@ -354,7 +381,9 @@ try {
         process.exitCode = 1;
         advanced = false;
       } else {
-        console.log(`  all ${pending.length} migration(s) recorded in the migrations table`);
+        console.log(
+          `  all ${pending.length} migration(s) recorded in the migrations table`,
+        );
       }
     }
 
@@ -365,14 +394,25 @@ try {
       console.log(
         `\n--- Reverse: skipped ---\n  ${blocked
           .map((m) => m.name)
-          .join(', ')} is intentionally irreversible, so reverting past it would ` +
+          .join(
+            ', ',
+          )} is intentionally irreversible, so reverting past it would ` +
           'prove nothing. Forward path above is still verified.',
       );
-      phases.push({ title: 'Reverse: skipped (irreversible migration in release)', ok: true, ms: 0 });
+      phases.push({
+        title: 'Reverse: skipped (irreversible migration in release)',
+        ok: true,
+        ms: 0,
+      });
     } else if (advanced) {
       for (let i = pending.length; i >= 1; i -= 1) {
         const target = pending[i - 1];
-        if (!(await phase(`Reverse: reverting ${target.name}`, 'migration:revert'))) {
+        if (
+          !(await phase(
+            `Reverse: reverting ${target.name}`,
+            'migration:revert',
+          ))
+        ) {
           advanced = false;
           break;
         }
@@ -384,7 +424,10 @@ try {
       // a `down()` that drops a column but leaves its index behind fails the
       // second `up()`, and nothing before this step would catch it.
       if (advanced) {
-        await phase('Re-apply: running the forward path a second time', 'migration:run');
+        await phase(
+          'Re-apply: running the forward path a second time',
+          'migration:run',
+        );
       }
     }
   }
@@ -393,7 +436,9 @@ try {
   if (phases.length > 0) {
     console.log('\n--- migration rehearsal ---');
     for (const entry of phases) {
-      console.log(`  ${entry.ok ? 'ok  ' : 'FAIL'}  ${seconds(entry.ms).padStart(7)}  ${entry.title}`);
+      console.log(
+        `  ${entry.ok ? 'ok  ' : 'FAIL'}  ${seconds(entry.ms).padStart(7)}  ${entry.title}`,
+      );
     }
     const total = phases.reduce((sum, entry) => sum + entry.ms, 0);
     console.log(`  ${' '.repeat(4)}  ${seconds(total).padStart(7)}  TOTAL`);
@@ -417,7 +462,8 @@ try {
         '| Phase | Result | Time |',
         '| --- | --- | --- |',
         ...phases.map(
-          (entry) => `| ${entry.title} | ${entry.ok ? 'pass' : '**FAIL**'} | ${seconds(entry.ms)} |`,
+          (entry) =>
+            `| ${entry.title} | ${entry.ok ? 'pass' : '**FAIL**'} | ${seconds(entry.ms)} |`,
         ),
         '',
         `Total ${seconds(total)}. Production was not touched.`,
@@ -433,7 +479,9 @@ try {
         'happened in the `migrate` job, against live data.',
     );
   } else if (phases.length > 0) {
-    console.log('\nRehearsal passed. These migrations apply to production-shaped data.');
+    console.log(
+      '\nRehearsal passed. These migrations apply to production-shaped data.',
+    );
   }
   // No `else`: a release with no pending migrations already said so, and must
   // not print a pass line claiming migrations were verified against real data.
@@ -442,7 +490,9 @@ try {
   // branch limit and starts failing every release.
   if (branchId && !keepBranch) {
     try {
-      await neon(`/branches/${encodeURIComponent(branchId)}`, { method: 'DELETE' });
+      await neon(`/branches/${encodeURIComponent(branchId)}`, {
+        method: 'DELETE',
+      });
       console.log(`\nDeleted rehearsal branch ${branchName} (${branchId})`);
     } catch (error) {
       console.error(

--- a/scripts/ci/migration-rehearsal.mjs
+++ b/scripts/ci/migration-rehearsal.mjs
@@ -41,8 +41,7 @@
  *   REHEARSAL_KEEP_BRANCH           set to 1 to leave the branch for inspection
  */
 import { spawn } from 'node:child_process';
-import { readdirSync } from 'node:fs';
-import { appendFileSync } from 'node:fs';
+import { appendFileSync, readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { Client } from 'pg';
 
@@ -57,18 +56,16 @@ const PREFIX = 'ci-migration-rehearsal/';
 // Migrations whose `down()` is deliberately a no-op, so reverting past them
 // proves nothing and the revert phase is skipped when one is in this release.
 //
-// This list is the second copy of the one in `migrations/migrations.spec.ts`
-// (`irreversible`), which names them in prose. Keep the two in step; better
-// still, give the migration classes a static marker both can read.
-//
-//   NormalizeExperienceLevels — the original free-text experience levels are
-//     gone once normalized; there is nothing to restore them from.
-//   HashRefreshTokens         — reversing it would write bearer credentials
-//     back in plaintext, which is the vulnerability it exists to remove.
-const IRREVERSIBLE = new Set([
-  'NormalizeExperienceLevels1781136000000',
-  'HashRefreshTokens1784073600000',
-]);
+// Single source of truth, shared with `migrations/migrations.spec.ts` — which
+// skips the rollback-SQL contract for the same entries, and asserts every key
+// names a migration that exists. `$comment` is documentation, not a class.
+const IRREVERSIBLE = new Set(
+  Object.keys(
+    JSON.parse(
+      readFileSync(new URL('../../migrations/irreversible.json', import.meta.url), 'utf8'),
+    ),
+  ).filter((key) => !key.startsWith('$')),
+);
 
 const apiKey = process.env.NEON_API_KEY?.trim();
 const projectId = process.env.NEON_PROJECT_ID?.trim();

--- a/scripts/ci/railway-rollback.mjs
+++ b/scripts/ci/railway-rollback.mjs
@@ -19,7 +19,8 @@
  *   GITHUB_STEP_SUMMARY  When set, the plan/result table is appended to it.
  */
 
-const ENDPOINT = process.env.RAILWAY_API_URL || 'https://backboard.railway.com/graphql/v2';
+const ENDPOINT =
+  process.env.RAILWAY_API_URL || 'https://backboard.railway.com/graphql/v2';
 
 // Rollback order mirrors deploy order: internal services first, the public
 // gateway last, so the front door is the last thing to change in either
@@ -35,7 +36,12 @@ const API_SERVICES = [
   'API Gateway',
 ];
 
-const MONITORING_SERVICES = ['alertmanager', 'blackbox-exporter', 'prometheus', 'grafana'];
+const MONITORING_SERVICES = [
+  'alertmanager',
+  'blackbox-exporter',
+  'prometheus',
+  'grafana',
+];
 
 const token = process.env.RAILWAY_TOKEN?.trim();
 if (!token) {
@@ -92,7 +98,9 @@ async function graphql(query, variables = {}) {
 
     const payload = await response.json();
     if (payload.errors?.length) {
-      throw new Error(`Railway API error: ${payload.errors.map((e) => e.message).join('; ')}`);
+      throw new Error(
+        `Railway API error: ${payload.errors.map((e) => e.message).join('; ')}`,
+      );
     }
     return payload.data;
   }
@@ -103,7 +111,14 @@ async function graphql(query, variables = {}) {
 // A project token already carries its project and environment; resolving them
 // this way means no extra secrets and no chance of pointing at the wrong
 // environment by hand.
-const context = await graphql(`query { projectToken { projectId environmentId } }`);
+const context = await graphql(`
+  query {
+    projectToken {
+      projectId
+      environmentId
+    }
+  }
+`);
 const projectId = context?.projectToken?.projectId;
 const environmentId = context?.projectToken?.environmentId;
 
@@ -115,20 +130,32 @@ if (!projectId || !environmentId) {
 }
 
 const project = await graphql(
-  `query ($id: String!) {
-    project(id: $id) {
-      name
-      services { edges { node { id name } } }
+  `
+    query ($id: String!) {
+      project(id: $id) {
+        name
+        services {
+          edges {
+            node {
+              id
+              name
+            }
+          }
+        }
+      }
     }
-  }`,
+  `,
   { id: projectId },
 );
 
-const services = (project?.project?.services?.edges ?? []).map((edge) => edge.node);
-console.log(`Project: ${project?.project?.name} (environment ${environmentId})`);
+const services = (project?.project?.services?.edges ?? []).map(
+  (edge) => edge.node,
+);
+console.log(
+  `Project: ${project?.project?.name} (environment ${environmentId})`,
+);
 
-const targetNames =
-  requested === 'all' ? API_SERVICES : [requested];
+const targetNames = requested === 'all' ? API_SERVICES : [requested];
 
 const resolved = targetNames.map((name) => {
   const match = services.find((service) => service.name === name);
@@ -144,11 +171,20 @@ const resolved = targetNames.map((name) => {
 /** The deployment currently serving traffic, and the one before it. */
 async function previousSuccessfulDeployment(serviceId) {
   const data = await graphql(
-    `query ($first: Int!, $input: DeploymentListInput!) {
-      deployments(first: $first, input: $input) {
-        edges { node { id status createdAt meta } }
+    `
+      query ($first: Int!, $input: DeploymentListInput!) {
+        deployments(first: $first, input: $input) {
+          edges {
+            node {
+              id
+              status
+              createdAt
+              meta
+            }
+          }
+        }
       }
-    }`,
+    `,
     { first: 20, input: { projectId, environmentId, serviceId } },
   );
 
@@ -177,14 +213,20 @@ async function previousSuccessfulDeployment(serviceId) {
 
 const plan = [];
 for (const service of resolved) {
-  const { current, target, considered } = await previousSuccessfulDeployment(service.id);
+  const { current, target, considered } = await previousSuccessfulDeployment(
+    service.id,
+  );
   plan.push({ service, current, target, considered });
 }
 
 const rows = plan.map(({ service, current, target }) => ({
   Service: service.name,
-  Current: current ? `${current.id.slice(0, 12)} (${current.createdAt})` : 'none',
-  'Roll back to': target ? `${target.id.slice(0, 12)} (${target.createdAt})` : '⚠️ no earlier deployment',
+  Current: current
+    ? `${current.id.slice(0, 12)} (${current.createdAt})`
+    : 'none',
+  'Roll back to': target
+    ? `${target.id.slice(0, 12)} (${target.createdAt})`
+    : '⚠️ no earlier deployment',
 }));
 console.table(rows);
 
@@ -198,16 +240,28 @@ if (unrollable.length > 0) {
 }
 
 if (!apply) {
-  console.log('\nDRY RUN — nothing was changed. Re-run with APPLY=1 to roll back.');
+  console.log(
+    '\nDRY RUN — nothing was changed. Re-run with APPLY=1 to roll back.',
+  );
   process.exit(0);
 }
 
 const results = [];
 for (const { service, target } of plan) {
   try {
-    await graphql(`mutation ($id: String!) { deploymentRollback(id: $id) }`, { id: target.id });
+    await graphql(
+      `
+        mutation ($id: String!) {
+          deploymentRollback(id: $id)
+        }
+      `,
+      { id: target.id },
+    );
     console.log(`Rolled back ${service.name} -> ${target.id}`);
-    results.push({ Service: service.name, Result: `rolled back to ${target.id.slice(0, 12)}` });
+    results.push({
+      Service: service.name,
+      Result: `rolled back to ${target.id.slice(0, 12)}`,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`FAILED to roll back ${service.name}: ${message}`);
@@ -232,7 +286,9 @@ if (process.env.GITHUB_STEP_SUMMARY) {
 
 const failures = results.filter((row) => row.Result.startsWith('FAILED'));
 if (failures.length > 0) {
-  throw new Error(`${failures.length} service(s) did not roll back. Finish them in the Railway dashboard.`);
+  throw new Error(
+    `${failures.length} service(s) did not roll back. Finish them in the Railway dashboard.`,
+  );
 }
 
 console.log('\nRollback complete. Verify /health/ready before standing down.');

--- a/scripts/ci/upload-db-backup.mjs
+++ b/scripts/ci/upload-db-backup.mjs
@@ -24,7 +24,8 @@ import { basename } from 'node:path';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 
 const file = process.argv[2];
-if (!file) throw new Error('Usage: node scripts/ci/upload-db-backup.mjs <dump-file>');
+if (!file)
+  throw new Error('Usage: node scripts/ci/upload-db-backup.mjs <dump-file>');
 
 const endpoint = process.env.S3_ENDPOINT?.trim();
 const bucket = process.env.S3_BACKUP_BUCKET?.trim();
@@ -38,14 +39,18 @@ const missing = [
   !secretAccessKey && 'S3_BACKUP_SECRET_ACCESS_KEY',
 ].filter(Boolean);
 if (missing.length) {
-  throw new Error(`Database backup upload is not configured. Missing: ${missing.join(', ')}`);
+  throw new Error(
+    `Database backup upload is not configured. Missing: ${missing.join(', ')}`,
+  );
 }
 
 const { size } = await stat(file);
 if (size === 0) {
   // A zero-byte dump is the worst outcome: it uploads fine, looks like a
   // backup, and restores nothing.
-  throw new Error(`${file} is empty. pg_dump produced no output — do not treat this as a backup.`);
+  throw new Error(
+    `${file} is empty. pg_dump produced no output — do not treat this as a backup.`,
+  );
 }
 
 // Date-prefixed so the bucket sorts chronologically and a human can find
@@ -58,7 +63,9 @@ const s3 = new S3Client({
   credentials: { accessKeyId, secretAccessKey },
 });
 
-console.log(`Uploading ${(size / 1024 / 1024).toFixed(1)} MB -> ${bucket}/${key}`);
+console.log(
+  `Uploading ${(size / 1024 / 1024).toFixed(1)} MB -> ${bucket}/${key}`,
+);
 
 try {
   await s3.send(

--- a/scripts/storage/migrate-in-container.mjs
+++ b/scripts/storage/migrate-in-container.mjs
@@ -121,7 +121,11 @@ async function collect() {
 /** Turn SDK failures into something actionable at 3am. */
 function explain(error) {
   const name = error?.name || '';
-  if (/CredentialsProviderError|InvalidAccessKeyId|SignatureDoesNotMatch/i.test(name)) {
+  if (
+    /CredentialsProviderError|InvalidAccessKeyId|SignatureDoesNotMatch/i.test(
+      name,
+    )
+  ) {
     return new Error(
       `S3 credentials rejected or missing (${name}). Set S3_ACCESS_KEY_ID and ` +
         'S3_SECRET_ACCESS_KEY on this service — see docs/STORAGE.md §4. ' +
@@ -146,7 +150,10 @@ async function head(key) {
   try {
     return await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
   } catch (error) {
-    if (error?.$metadata?.httpStatusCode === 404 || error?.name === 'NotFound') {
+    if (
+      error?.$metadata?.httpStatusCode === 404 ||
+      error?.name === 'NotFound'
+    ) {
       return null;
     }
     throw explain(error);
@@ -297,4 +304,6 @@ if (problems.length > 0) {
   process.exit(1);
 }
 
-console.log(`\nVerified ${files.length} files. Safe to proceed to STORAGE.md §4.`);
+console.log(
+  `\nVerified ${files.length} files. Safe to proceed to STORAGE.md §4.`,
+);

--- a/scripts/upload-sourcemaps.mjs
+++ b/scripts/upload-sourcemaps.mjs
@@ -32,7 +32,9 @@ if (!token || !org || !project) {
     !org && 'SENTRY_ORG',
     !project && 'SENTRY_PROJECT',
   ].filter(Boolean);
-  console.log(`[sentry] skipping source map upload — missing ${missing.join(', ')}`);
+  console.log(
+    `[sentry] skipping source map upload — missing ${missing.join(', ')}`,
+  );
   process.exit(0);
 }
 
@@ -42,14 +44,18 @@ if (!existsSync(distDir)) {
 }
 
 // Same resolution order as instrument.ts, so events and artifacts line up.
-const release = process.env.SENTRY_RELEASE || process.env.RAILWAY_GIT_COMMIT_SHA;
+const release =
+  process.env.SENTRY_RELEASE || process.env.RAILWAY_GIT_COMMIT_SHA;
 
 // sentry-cli auto-reads .env and warns when it cannot parse it; we already
 // loaded it above and pass everything explicitly, so turn that off.
 const env = { ...process.env, SENTRY_LOAD_DOTENV: '0' };
 
 function run(args) {
-  const res = spawnSync('npx', ['sentry-cli', ...args], { stdio: 'inherit', env });
+  const res = spawnSync('npx', ['sentry-cli', ...args], {
+    stdio: 'inherit',
+    env,
+  });
   if (res.status !== 0) {
     console.error(`[sentry] command failed: sentry-cli ${args.join(' ')}`);
     process.exit(res.status ?? 1);


### PR DESCRIPTION
Four independent changes, stacked into one PR so they cost one release
rather than four. Each is a separate commit and reviewable on its own.

Zero runtime behaviour changes. Nothing here touches service code.

### `chore: point nest-cli root at a directory that exists`
#82 left the top-level `root` on `apps/AparaTalent`, a directory this
repository has never contained. Harmless at runtime; it just sends the
next person after a path that is not there.

### `ci: pin every action to a commit SHA`
All 39 action references were mutable tags. `codeql.yml` already
analyses the `actions` language *because* these workflows are attack
surface, and they hold `RAILWAY_TOKEN`, `DATABASE_URL`, `NEON_API_KEY`
and the S3 backup credentials. trivy-action was already pinned;
everything else now matches. Dependabot's github-actions ecosystem
understands this form and bumps the SHA and comment together.

### `refactor(migrations): one source of truth for irreversible migrations`
The list existed twice, in two naming schemes, with nothing keeping them
in step — and the failure was silent in the worst direction. Now one
`migrations/irreversible.json`, plus a test asserting every key names a
migration that exists.

### `ci: lint the .mjs scripts that run the releases`
`lint:check` globbed only `*.ts`, so nine ESM scripts — deploy,
rollback, backup, recovery, migration rehearsal — were checked by
nothing. All 85 findings were formatting; zero correctness issues.

## Verification

Run locally on the combined branch, not per-branch:

- `lint:check` exit 0
- `build:all` exit 0
- full unit suite exit 0, migration spec 25/25
- all 14 `.mjs` pass `node --check`
- every action reference resolves to a 40-char SHA
- all 6 workflows parse
- `migration-rehearsal.mjs` still creates and cleans up its branch against a stubbed control plane
- the new irreversible guard was proven to fail on a bogus entry and pass once removed

Supersedes #85, #86, #87, #88 — close those unmerged.