### PR TITLE
ops: gate production behind an approval, and add the digest probe

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -473,6 +473,23 @@ jobs:
     timeout-minutes: 20
     needs: [release-preflight, migration-rehearsal]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # The gate goes HERE, not on `deploy`, because this is the first job that
+    # writes to production and the only one whose effects a rollback cannot
+    # fully undo. Gating `deploy` instead would ask for approval after the
+    # schema had already changed.
+    #
+    # One approval covers the whole production phase — `deploy` needs this job,
+    # so there is no second prompt. And because `migration-rehearsal` runs
+    # before it, the rehearsal result is already visible when the decision is
+    # made: you are approving a migration that has been proven to apply to a
+    # copy of the real data.
+    #
+    # `prevent_self_review` is deliberately false on this environment. GitHub
+    # forbids approving your own pull request but permits approving your own
+    # deployment, which is the only reason this is usable by one person. It is
+    # not a second pair of eyes — it is a deliberate stop between merging and
+    # migrating production.
+    environment: production-release
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/scripts/ci/digest-probe.mjs
+++ b/scripts/ci/digest-probe.mjs
@@ -1,0 +1,354 @@
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Settle one question before build-once-deploy-many is attempted a second time:
+ *
+ *   When a Railway service points at a MUTABLE image tag, and that tag is
+ *   later moved to a different image, does rolling back to an earlier
+ *   deployment restore the image that deployment actually ran — or does it
+ *   re-resolve the tag and pull the newest one?
+ *
+ * This matters because it is the only thing standing between the current
+ * `railway up` deploy (which rebuilds from source, costs ~15 minutes a release,
+ * and ships an artifact nothing scanned) and option 2 in PR #79. If rollback
+ * re-resolves the tag, adopting a mutable tag would trade a scanned-artifact
+ * gap for a broken recovery path — a strictly worse deal, and one that would
+ * not be discovered until an incident.
+ *
+ * The evidence so far says digests ARE pinned: every deployment record in this
+ * project carries `meta.imageDigest`, source-built ones included, and
+ * `deploymentRollback` takes only a deployment id while `deploymentRedeploy`
+ * exposes a `usePreviousImageTag` flag. That is inference from stored data and
+ * API shape. This performs the experiment.
+ *
+ * WHAT IT DOES
+ *
+ *   1. create a throwaway service from a public image at a mutable tag
+ *   2. record the deployment's resolved digest              (digest A)
+ *   3. point the SAME tag at a different image, redeploy
+ *   4. record the new deployment's resolved digest          (digest B)
+ *   5. roll back to deployment 1
+ *   6. read the resulting deployment's digest and compare
+ *
+ *      digest == A  ->  rollback is pinned. Option 2 is safe.
+ *      digest == B  ->  rollback re-resolves. Do NOT adopt a mutable tag.
+ *
+ * Step 3 needs two distinct images reachable at one moving tag. Rather than
+ * push anything, it uses two well-known public images and moves the SERVICE
+ * between them, which is the same control-plane operation a moved tag causes:
+ * the deployment record is written from whatever the source resolved to.
+ *
+ * SAFETY
+ *
+ *   - Touches nothing that exists. It creates a service whose name starts with
+ *     `zz-digest-probe-`, and deletes only that.
+ *   - Never runs against a service in the application or monitoring set; the
+ *     name is generated here and checked before every destructive call.
+ *   - Default is a dry run. Nothing is created without --apply.
+ *   - `--cleanup` deletes leftover probe services and exits.
+ *
+ * REQUIRES an ACCOUNT-authenticated Railway CLI (`railway whoami`), not a
+ * project token. Setting a service's source is exactly the capability the CI
+ * project token lacks — that is what broke #78.
+ *
+ *   node scripts/ci/digest-probe.mjs                # dry run, prints the plan
+ *   node scripts/ci/digest-probe.mjs --apply        # perform the experiment
+ *   node scripts/ci/digest-probe.mjs --cleanup      # remove leftovers
+ *
+ * Environment:
+ *   RAILWAY_PROJECT_ID  defaults to the apsaratalent production project.
+ *   RAILWAY_ENV_ID      defaults to the production environment.
+ *   PROBE_KEEP_SERVICE  set to 1 to leave the probe service for inspection.
+ */
+const PROJECT_ID =
+  process.env.RAILWAY_PROJECT_ID || '25a2e450-b6e7-430c-868c-5adb27de4d2c';
+const ENVIRONMENT_ID =
+  process.env.RAILWAY_ENV_ID || 'db8b2f83-a515-4555-986a-3c79c2bb052c';
+
+// Reserved prefix. Cleanup and deletion only ever consider names starting with
+// this, so a real service can never be the target of a destructive call.
+const PREFIX = 'zz-digest-probe-';
+
+// Two distinct public images, both small and both certain to resolve to
+// different digests. Neither is used by this project.
+const IMAGE_A = 'nginx:1.29-alpine';
+const IMAGE_B = 'nginx:1.28-alpine';
+
+const apply = process.argv.includes('--apply');
+const cleanupOnly = process.argv.includes('--cleanup');
+
+/**
+ * Checked lazily, so the default dry run explains the plan on a machine with
+ * no Railway credential at all.
+ *
+ * The CLI is the transport rather than a raw fetch with the token out of
+ * ~/.railway/config.json: that stored `accessToken` is rejected by the public
+ * GraphQL endpoint ("Not Authorized"), and reverse-engineering which
+ * credential form the endpoint wants is not worth owning here. `railway api`
+ * is already authenticated and already pinned in CI.
+ */
+function requireAccountAuth() {
+  try {
+    const who = execFileSync('railway', ['whoami'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    console.log(`Railway: ${who.trim()}`);
+  } catch {
+    throw new Error(
+      'Not logged in to Railway. Run `railway login` — and note it must be an ' +
+        "ACCOUNT login, because a project token cannot set a service's source, " +
+        'which is the whole point of this probe.',
+    );
+  }
+}
+
+function gql(query, variables = {}) {
+  let stdout;
+  try {
+    stdout = execFileSync(
+      'railway',
+      ['api', query, '--variables', JSON.stringify(variables), '--compact'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 60_000 },
+    );
+  } catch (error) {
+    const detail = `${error.stderr || ''}${error.stdout || ''}`.trim();
+    throw new Error(`Railway API call failed: ${detail.slice(0, 400)}`);
+  }
+
+  let body;
+  try {
+    body = JSON.parse(stdout);
+  } catch {
+    throw new Error(`Railway API returned non-JSON: ${stdout.slice(0, 200)}`);
+  }
+  if (body.errors) {
+    throw new Error(
+      `Railway API: ${body.errors
+        .map((e) => e.message)
+        .join('; ')
+        .slice(0, 300)}`,
+    );
+  }
+  return body.data ?? body;
+}
+
+function listProbeServices() {
+  const data = gql(
+    `query ($id: String!) {
+      project(id: $id) { services { edges { node { id name } } } }
+    }`,
+    { id: PROJECT_ID },
+  );
+  return data.project.services.edges
+    .map((e) => e.node)
+    .filter((s) => s.name.startsWith(PREFIX));
+}
+
+function deleteService(service) {
+  // Belt and braces: the filter above already scoped this, but a delete call is
+  // worth guarding twice.
+  if (!service.name.startsWith(PREFIX)) {
+    throw new Error(
+      `Refusing to delete "${service.name}" — not a probe service.`,
+    );
+  }
+  gql(`mutation ($id: String!) { serviceDelete(id: $id) }`, {
+    id: service.id,
+  });
+  console.log(`  deleted ${service.name} (${service.id})`);
+}
+
+function latestDeployment(serviceId) {
+  const data = gql(
+    `query ($projectId: String!, $serviceId: String!) {
+      deployments(first: 1, input: {projectId: $projectId, serviceId: $serviceId}) {
+        edges { node { id status createdAt meta } }
+      }
+    }`,
+    { projectId: PROJECT_ID, serviceId },
+  );
+  return data.deployments.edges[0]?.node;
+}
+
+async function waitForDeployment(serviceId, notId, label) {
+  const deadline = Date.now() + 8 * 60_000;
+  let last = '';
+  while (Date.now() < deadline) {
+    const deployment = latestDeployment(serviceId);
+    if (deployment && deployment.id !== notId) {
+      if (deployment.status === 'SUCCESS') {
+        console.log(`  ${label}: SUCCESS (${deployment.id.slice(0, 8)})`);
+        return deployment;
+      }
+      if (['FAILED', 'CRASHED'].includes(deployment.status)) {
+        throw new Error(`${label} ended ${deployment.status}.`);
+      }
+      if (deployment.status !== last) {
+        console.log(`  ${label}: ${deployment.status}...`);
+        last = deployment.status;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 5_000));
+  }
+  throw new Error(`${label} did not reach SUCCESS within 8 minutes.`);
+}
+
+const digestOf = (deployment) => deployment?.meta?.imageDigest || '(none)';
+const imageOf = (deployment) => deployment?.meta?.image || '(source build)';
+
+// --------------------------------------------------------------- cleanup ----
+if (cleanupOnly) {
+  requireAccountAuth();
+  const stale = listProbeServices();
+  if (stale.length === 0) {
+    console.log('No probe services to clean up.');
+    process.exit(0);
+  }
+  console.log(`Deleting ${stale.length} probe service(s)...`);
+  for (const service of stale) deleteService(service);
+  process.exit(0);
+}
+
+// ------------------------------------------------------------- dry run ----
+const serviceName = `${PREFIX}${Date.now()}`;
+
+if (!apply) {
+  console.log('DRY RUN — nothing will be created. Re-run with --apply.\n');
+  console.log('Plan:');
+  console.log(`  1. create service   ${serviceName}`);
+  console.log(`  2. source -> ${IMAGE_A}, deploy, record digest A`);
+  console.log(`  3. source -> ${IMAGE_B}, deploy, record digest B`);
+  console.log('  4. roll back to the first deployment');
+  console.log('  5. compare the rolled-back digest against A and B');
+  console.log(`  6. delete ${serviceName}`);
+  console.log(`\nProject ${PROJECT_ID}, environment ${ENVIRONMENT_ID}.`);
+  console.log('Existing services are never touched; only names starting with');
+  console.log(`"${PREFIX}" are created or deleted.`);
+  process.exit(0);
+}
+
+// ------------------------------------------------------------ experiment ----
+requireAccountAuth();
+
+let serviceId;
+try {
+  console.log(`Creating probe service ${serviceName}...`);
+  const created = gql(
+    `mutation ($input: ServiceCreateInput!) { serviceCreate(input: $input) { id name } }`,
+    {
+      input: {
+        projectId: PROJECT_ID,
+        name: serviceName,
+        source: { image: IMAGE_A },
+      },
+    },
+  );
+  serviceId = created.serviceCreate.id;
+  console.log(`  ${serviceName} (${serviceId})`);
+
+  console.log(`\nDeployment 1 — source ${IMAGE_A}`);
+  const first = await waitForDeployment(serviceId, null, 'deployment 1');
+  const digestA = digestOf(first);
+  console.log(`  image:  ${imageOf(first)}`);
+  console.log(`  digest: ${digestA}`);
+
+  console.log(`\nMoving source to ${IMAGE_B} (stands in for a moved tag)...`);
+  gql(
+    `mutation ($id: String!, $environmentId: String!, $input: ServiceInstanceUpdateInput!) {
+      serviceInstanceUpdate(serviceId: $id, environmentId: $environmentId, input: $input)
+    }`,
+    {
+      id: serviceId,
+      environmentId: ENVIRONMENT_ID,
+      input: { source: { image: IMAGE_B } },
+    },
+  );
+  gql(
+    `mutation ($environmentId: String!, $serviceId: String!) {
+      serviceInstanceRedeploy(environmentId: $environmentId, serviceId: $serviceId)
+    }`,
+    { environmentId: ENVIRONMENT_ID, serviceId },
+  );
+
+  const second = await waitForDeployment(serviceId, first.id, 'deployment 2');
+  const digestB = digestOf(second);
+  console.log(`  image:  ${imageOf(second)}`);
+  console.log(`  digest: ${digestB}`);
+
+  if (digestA === digestB) {
+    throw new Error(
+      'Both deployments resolved to the same digest, so the experiment cannot ' +
+        'distinguish pinned from re-resolved. Pick two more different images.',
+    );
+  }
+
+  console.log(`\nRolling back to deployment 1 (${first.id.slice(0, 8)})...`);
+  gql(`mutation ($id: String!) { deploymentRollback(id: $id) }`, {
+    id: first.id,
+  });
+
+  const rolled = await waitForDeployment(serviceId, second.id, 'rollback');
+  const digestRolled = digestOf(rolled);
+  console.log(`  image:  ${imageOf(rolled)}`);
+  console.log(`  digest: ${digestRolled}`);
+
+  // ------------------------------------------------------------ verdict ----
+  console.log('\n--- result ---');
+  console.log(`  A (first deploy):  ${digestA}`);
+  console.log(`  B (after move):    ${digestB}`);
+  console.log(`  after rollback:    ${digestRolled}`);
+  console.log('');
+
+  if (digestRolled === digestA) {
+    console.log(
+      'PINNED. Rollback restored the digest that deployment actually ran.',
+    );
+    console.log(
+      'Option 2 in PR #79 is safe: a mutable tag can be adopted without',
+    );
+    console.log(
+      'weakening the rollback path, because the deployment record — not',
+    );
+    console.log('the tag — is what recovery resolves.');
+  } else if (digestRolled === digestB) {
+    console.log(
+      'RE-RESOLVED. Rollback pulled the NEWEST image at the tag, not the',
+    );
+    console.log(
+      'one that deployment ran. Do NOT adopt a mutable tag: rolling back',
+    );
+    console.log(
+      'would silently redeploy the broken release. Use an immutable tag',
+    );
+    console.log(
+      'per release instead, which needs an account-scoped token in CI.',
+    );
+    process.exitCode = 1;
+  } else {
+    console.log(
+      'INCONCLUSIVE — the rolled-back digest matches neither A nor B.',
+    );
+    console.log(
+      'Do not act on this run. Inspect the service before deleting it:',
+    );
+    console.log(`  railway logs --service ${serviceName}`);
+    process.exitCode = 1;
+  }
+} finally {
+  if (serviceId && process.env.PROBE_KEEP_SERVICE !== '1') {
+    console.log('\nCleaning up...');
+    try {
+      deleteService({ id: serviceId, name: serviceName });
+    } catch (error) {
+      console.error(
+        `WARNING: could not delete ${serviceName} (${error.message}). ` +
+          'Delete it in the Railway dashboard, or re-run with --cleanup.',
+      );
+    }
+  } else if (serviceId) {
+    console.log(
+      `\nKept ${serviceName} — PROBE_KEEP_SERVICE=1. Remove it with --cleanup.`,
+    );
+  }
+}


### PR DESCRIPTION
Two changes on the release path.

## Approval gate

A merge to main currently runs DDL against the production database
completely unattended. Rollback was deliberately kept a human decision
(RUNBOOK §4); the forward path being fully automatic was the
inconsistency.

The `production-release` environment is on the `migrate` job, not
`deploy`, because migrate is the first job that writes to production and
the only one whose effects a rollback cannot fully undo. Gating `deploy`
would ask for approval after the schema had already changed. One
approval covers the whole production phase — deploy needs migrate, so
there is no second prompt.

It also lands in the right order: migration-rehearsal runs before it, so
the rehearsal result is visible when the decision is made. You approve a
migration already proven to apply to a copy of the real data.

`prevent_self_review` is false on the environment. GitHub forbids
approving your own pull request but permits approving your own
deployment, which is the only reason this is usable by one person. It is
not a second pair of eyes — it is a deliberate stop between merging and
migrating production.

## Digest probe

scripts/ci/digest-probe.mjs settles the question blocking option 2 in
#79: when a service points at a mutable tag and that tag moves, does
rollback restore the image the deployment ran, or re-resolve the tag?

Everything found so far says pinned — every deployment record carries
meta.imageDigest, source-built ones included, and deploymentRollback
takes only a deployment id while deploymentRedeploy exposes
usePreviousImageTag. That is inference. This performs the experiment on
a throwaway service and reports PINNED / RE-RESOLVED / INCONCLUSIVE.

Manual tool, wired to no workflow. Dry run by default; --apply performs
it; --cleanup removes leftovers. Every destructive call is guarded twice
on the reserved `zz-digest-probe-` prefix, so an application or
monitoring service can never be the target.

The CLI is the transport rather than a raw fetch: the accessToken in
~/.railway/config.json is rejected by the public GraphQL endpoint
("Not Authorized"), and `railway api` is already authenticated and
already pinned in CI.

Verified: dry run works with no credential present; --cleanup
authenticates and queries the live project (found nothing, exit 0);
mutation signatures checked against the live schema; lint:check exits 0
and all six workflows parse.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
