### PR TITLE
ci: publish a :main tag alongside the immutable SHA tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -197,12 +197,26 @@ jobs:
 
       # Only from main. A pull request builds and scans the identical image but
       # must not be able to publish one.
+      #
+      # Two tags, one image. The SHA tag is the immutable identity and stays the
+      # thing Trivy scans below. `:main` is a moving pointer to the same digest,
+      # and exists because a Railway service source has to be set by hand with
+      # account credentials — the CI project token cannot change it (#78). A
+      # service pinned to `:main` can therefore be pointed once and then
+      # redeployed by CI forever.
+      #
+      # Moving the tag is safe for recovery: the digest probe established that
+      # Railway records the RESOLVED digest per deployment and rolls back to
+      # that, not to whatever the tag points at now. See scripts/ci/digest-probe.mjs.
       - name: Publish to GHCR
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: bash
         run: |
+          image="ghcr.io/rithybondeth/apsaratalent-${{ matrix.service }}"
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-          docker push "ghcr.io/rithybondeth/apsaratalent-${{ matrix.service }}:${{ github.sha }}"
+          docker push "${image}:${{ github.sha }}"
+          docker tag "${image}:${{ github.sha }}" "${image}:main"
+          docker push "${image}:main"
           docker logout ghcr.io
 
       # The image is scanned, not merely built. `npm audit` sees the JavaScript
@@ -339,12 +353,16 @@ jobs:
           --tag ghcr.io/rithybondeth/apsaratalent-monitoring-${{ matrix.service }}:${{ github.sha }}
           .
 
+      # Same two-tag scheme as the application services above.
       - name: Publish to GHCR
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: bash
         run: |
+          image="ghcr.io/rithybondeth/apsaratalent-monitoring-${{ matrix.service }}"
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-          docker push "ghcr.io/rithybondeth/apsaratalent-monitoring-${{ matrix.service }}:${{ github.sha }}"
+          docker push "${image}:${{ github.sha }}"
+          docker tag "${image}:${{ github.sha }}" "${image}:main"
+          docker push "${image}:main"
           docker logout ghcr.io
 
       # These four are upstream images with a config layer on top, so their CVEs


### PR DESCRIPTION
Step 1 of three toward deploying the image that was scanned. This one is
inert: it publishes an extra tag and changes nothing about how anything
deploys.

Both tags point at the same digest. The SHA tag remains the immutable
identity and remains what Trivy scans — the gate is unchanged, and
scanning `:main` instead would mean scanning a moving target.

`:main` exists because a Railway service source can only be set with
account credentials; the CI project token cannot change it, which is
exactly what broke #78. A service pointed once at `:main` by hand can
then be deployed by CI indefinitely.

Moving a tag is safe for recovery, and that is measured rather than
assumed: scripts/ci/digest-probe.mjs established that Railway records
the resolved digest per deployment and rolls back to that digest, not to
whatever the tag currently points at.

  A (first deploy)  sha256:5616878...
  B (after move)    sha256:a8b39bd...
  after rollback    sha256:5616878...  == A

Ordering matters and is why this is separate: no `:main` tag exists in
GHCR today (9 tags, all SHAs), so pointing a service at it before this
lands would fail on a tag that is not there.

Steps 2 and 3, once one release has published the tag: point Notification
Service at `:main` by hand, and switch that one deploy step from
`railway up` to a deploy-from-source call. Ten services stay on
`railway up` until the canary has shipped a few releases.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
