### PR TITLE
ops: deploy notification service from its image, not a rebuild

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -629,8 +629,21 @@ jobs:
       - name: Deploy job service
         run: scripts/ci/railway-up.sh "Job Service"
 
+      # CANARY — the only service on the image path. The other ten still
+      # rebuild via `railway up`, deliberately: converting all eleven at once is
+      # how #78 failed, and this one is the safest to be wrong about because
+      # nothing in the gateway request path calls into it.
+      #
+      # Its source was pointed at :main by hand, with account credentials. The
+      # project token used here cannot change a source (that IS what broke #78)
+      # but it can deploy, which is the whole basis of this approach.
+      #
+      # If this misbehaves, the fallback is one dashboard change — set the
+      # source back to the repo with builder RAILPACK and dockerfilePath
+      # /apps/notification-service/Dockerfile — and revert this step to
+      # `scripts/ci/railway-up.sh "Notification Service"`.
       - name: Deploy notification service
-        run: scripts/ci/railway-up.sh "Notification Service"
+        run: scripts/ci/railway-deploy-from-source.sh "Notification Service"
 
       - name: Deploy Alertmanager
         run: scripts/ci/railway-up.sh alertmanager

--- a/scripts/ci/railway-deploy-from-source.sh
+++ b/scripts/ci/railway-deploy-from-source.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# Deploy one Railway service from its configured source, and wait for that
+# deployment to actually become healthy.
+#
+# For a service whose source is a registry image, this pulls whatever the tag
+# now points at — which is how build-once-deploy-many works here: the
+# `containers` job builds the image, scans it, pushes it as both :<sha> and
+# :main, and this step tells Railway to take it. No rebuild.
+#
+# WHY NOT `railway up`
+#
+# `railway up` uploads the working directory and has Railway build it, so the
+# artifact that runs is a rebuild of the source rather than the image that was
+# scanned. It also costs ~1.5-3.8 minutes per service; the whole deploy job was
+# 17 minutes, 63% of a release, rebuilding 11 images the containers job had
+# already built in parallel in 2.5.
+#
+# WHY `--from-source` IS LOAD-BEARING
+#
+# Bare `railway redeploy` re-runs the EXISTING deployment — it would redeploy
+# the old image and report success, shipping nothing. `--from-source` is
+# documented as "pull and deploy the latest commit or image from the configured
+# source", and that difference was measured: the first digest-probe run moved a
+# service's source and got the previous image back, because it used the redeploy
+# operation rather than the deploy one.
+#
+# WHY THE WAIT
+#
+# `railway redeploy` returns as soon as Railway accepts the request (~3.7s,
+# measured 2026-08-08). `railway up` in attached mode blocks until the service
+# is active, and every release depends on that guarantee — without polling here
+# a release would report success the moment the request was accepted, and
+# verify-deployment.mjs would run against the previous revision.
+#
+# RETRIES are transport-shaped only, same policy and same reasoning as
+# railway-up.sh: a failed deploy fails the same way three times, and retrying it
+# just buries the real error.
+#
+# Usage:  scripts/ci/railway-deploy-from-source.sh "Notification Service"
+# Env:    RAILWAY_DEPLOY_ATTEMPTS  (default 3)
+#         RAILWAY_DEPLOY_TIMEOUT   seconds to wait for SUCCESS (default 600)
+
+set -uo pipefail
+
+service="${1:?usage: railway-deploy-from-source.sh <service name>}"
+attempts="${RAILWAY_DEPLOY_ATTEMPTS:-3}"
+timeout="${RAILWAY_DEPLOY_TIMEOUT:-600}"
+
+TRANSIENT='operation timed out|reqwest error|error sending request|connection (reset|refused|closed|error)|tcp connect error|dns error|handshake|EOF while parsing|502 Bad Gateway|503 Service|504 Gateway|temporarily unavailable'
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+# The id of the deployment that is serving right now. The new one is whatever
+# appears that is not this, which is what makes the wait below able to tell a
+# fresh rollout from the previous revision still answering.
+current_deployment() {
+  railway deployment list --service "$service" --limit 1 --json 2>/dev/null \
+    | sed -n '/^[[{]/,$p' \
+    | node -e "
+      let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{
+        try {
+          const j = JSON.parse(s);
+          const list = Array.isArray(j) ? j : (j.deployments || j.data || []);
+          process.stdout.write(list[0]?.id || '');
+        } catch { process.stdout.write(''); }
+      });"
+}
+
+# Prints "<id> <status>" for the newest deployment.
+latest_deployment() {
+  railway deployment list --service "$service" --limit 1 --json 2>/dev/null \
+    | sed -n '/^[[{]/,$p' \
+    | node -e "
+      let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{
+        try {
+          const j = JSON.parse(s);
+          const list = Array.isArray(j) ? j : (j.deployments || j.data || []);
+          const d = list[0];
+          process.stdout.write(d ? \`\${d.id} \${d.status}\` : '');
+        } catch { process.stdout.write(''); }
+      });"
+}
+
+previous="$(current_deployment)"
+echo "Deploying ${service} from its configured source (was ${previous:-none})."
+
+deployed=0
+for attempt in $(seq 1 "$attempts"); do
+  if [[ "$attempt" -gt 1 ]]; then
+    echo "::notice::Retrying deploy of ${service} (attempt ${attempt}/${attempts})"
+  fi
+
+  railway redeploy --service "$service" --from-source --yes 2>&1 | tee "$log"
+  status="${PIPESTATUS[0]}"
+
+  if [[ "$status" -eq 0 ]]; then
+    deployed=1
+    break
+  fi
+
+  if ! grep -qiE "$TRANSIENT" "$log"; then
+    echo "::error::Deploying ${service} failed (exit ${status}) and the error is not transient — not retrying."
+    exit "$status"
+  fi
+
+  if [[ "$attempt" -eq "$attempts" ]]; then
+    echo "::error::Deploying ${service} failed ${attempts} times with transport errors. Check https://status.railway.com before re-running."
+    exit "$status"
+  fi
+
+  backoff=$((10 * (2 ** (attempt - 1))))
+  echo "Transient failure deploying ${service}; retrying in ${backoff}s."
+  sleep "$backoff"
+done
+
+[[ "$deployed" -eq 1 ]] || exit 1
+
+echo "Request accepted. Waiting for ${service} to become active..."
+
+deadline=$(( $(date +%s) + timeout ))
+last_status=""
+while [[ "$(date +%s)" -lt "$deadline" ]]; do
+  read -r id state <<<"$(latest_deployment)"
+
+  if [[ -n "${id:-}" && "$id" != "$previous" ]]; then
+    case "$state" in
+      SUCCESS)
+        echo "${service} is active on ${id}."
+        exit 0
+        ;;
+      FAILED|CRASHED)
+        echo "::error::${service} deployment ${id} ended ${state}. Logs: railway logs --service \"${service}\""
+        exit 1
+        ;;
+      *)
+        if [[ "$state" != "$last_status" ]]; then
+          echo "  ${state}..."
+          last_status="$state"
+        fi
+        ;;
+    esac
+  fi
+
+  sleep 5
+done
+
+echo "::error::${service} did not reach SUCCESS within ${timeout}s (last status: ${last_status:-unknown})."
+exit 1


### PR DESCRIPTION
Step 3 of three, and the canary. One service of eleven moves to the
image path; the other ten still rebuild via `railway up`.

Notification Service because nothing in the gateway request path calls
into it, so being wrong about it is contained. Converting all eleven at
once is exactly how #78 failed.

## What changed outside this repo

Its source was pointed at
ghcr.io/rithybondeth/apsaratalent-notification-service:main by hand,
using account credentials. The CI project token cannot change a source —
that is the bug #78 died on — but it can deploy, which is what makes
this approach work at all.

Verified after the change: Notification Service source.image is set and
source.repo is null; Auth Service is still on the repo source, so the
blast radius is one service.

## Why `--from-source`

Bare `railway redeploy` re-runs the EXISTING deployment: it would
redeploy the old image and report success, shipping nothing. The flag is
documented as "pull and deploy the latest commit or image from the
configured source", and the difference is measured — the first
digest-probe run moved a source and got the previous image back because
it used the redeploy operation instead of the deploy one.

## Why the wait

`railway redeploy` returns as soon as Railway accepts the request
(~3.7s). `railway up` in attached mode blocks until the service is
active and every release depends on that guarantee, so the wrapper polls
`railway deployment list` until the newest deployment — identified as
"not the one that was serving before" — reaches SUCCESS, and fails on
FAILED, CRASHED or timeout. Retries stay transport-shaped only, same
policy as railway-up.sh.

## Rollback

One dashboard change (source back to the repo, builder RAILPACK,
dockerfilePath /apps/notification-service/Dockerfile) plus reverting
this step to railway-up.sh. Recorded in the workflow comment so it is
not archaeology mid-incident.

Deployment records pin the resolved digest, so rolling back this service
still restores the image that deployment ran — measured, not assumed:
scripts/ci/digest-probe.mjs.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
