### PR TITLE
ci: actually run the load harness, instead of only validating its config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,8 +128,19 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-      - name: Run isolated end-to-end tests
+      # E2E_LOAD adds a load phase inside the same run, against the same
+      # already-standing isolated stack. `test:load:check` in the build job
+      # validates the harness configuration but sends no requests, so until now
+      # nothing has ever measured whether a change made a hot path slower.
+      #
+      # Thresholds are deliberately loose (see test/e2e/run-e2e.mjs): a shared
+      # runner cannot support a tight latency gate without becoming flaky, and a
+      # gate people rerun until it passes is worse than no gate. This catches a
+      # hot path becoming several times slower or erroring under concurrency.
+      - name: Run isolated end-to-end tests and load phase
         run: npm run test:e2e
+        env:
+          E2E_LOAD: '1'
 
   build:
     name: Typecheck and build every service

--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -10,6 +10,36 @@ Validate the configuration without sending requests:
 npm run test:load:check
 ```
 
+## In CI
+
+Every push and pull request runs a load phase inside the end-to-end run, against
+the same isolated stack the e2e specs use — the gateway on `127.0.0.1:13000`,
+backed by the throwaway Postgres and Redis on 15432/16379. It runs there because
+that is the only point at which the stack is already standing; a separate job
+would have to build all of it again to measure the same thing.
+
+It probes `/health/ready` rather than `/health`, because readiness touches the
+database and Redis and so measures the path a real request depends on. A
+liveness handler returns a constant and would stay fast no matter what
+regressed.
+
+Run it locally the same way CI does:
+
+```bash
+E2E_LOAD=1 npm run test:e2e
+```
+
+**The thresholds are a starting point, not a calibrated gate.** `LOAD_MAX_P95_MS`
+is 2000ms, which catches a hot path that has gone seconds slow or that errors
+under concurrency — it will not catch a regression from 50ms to 150ms. After the
+first green run, take the p95 the harness prints and set the threshold to
+roughly 3x it, then tighten as the number settles. Every value is overridable
+from the workflow, so calibrating is a one-line change.
+
+Do not tighten past what a shared runner can hold. A flaky gate is worse than no
+gate: people rerun it until it passes, and learn to ignore the one signal it
+exists to give.
+
 Run the default local health test:
 
 ```bash

--- a/test/e2e/run-e2e.mjs
+++ b/test/e2e/run-e2e.mjs
@@ -306,6 +306,50 @@ try {
       },
     },
   );
+
+  // The load harness has existed since the start but has never actually run in
+  // CI — only `test:load:check`, which validates configuration and sends no
+  // requests. So nothing has ever measured whether a change makes a hot path
+  // slower, and a 3x regression would reach production unnoticed.
+  //
+  // It runs HERE, inside the e2e run, because this is the only place the stack
+  // is already standing: same isolated Postgres and Redis on 15432/16379, same
+  // gateway on 13000, torn down by the same `finally`. A separate CI job would
+  // have to build all of that a second time to measure the same thing.
+  //
+  // Opt-in so a local `npm run test:e2e` does not get slower by default.
+  if (process.env.E2E_LOAD === '1') {
+    process.stdout.write('\nRunning load phase against the e2e gateway...\n');
+    await run(process.execPath, [join(root, 'scripts/load/smoke-load.mjs')], {
+      env: {
+        ...process.env,
+        ...env,
+        LOAD_BASE_URL: 'http://127.0.0.1:13000',
+        // Readiness, not liveness: /health/ready touches the database and
+        // Redis, so this measures the path a real request depends on rather
+        // than a constant handler that would stay fast whatever regressed.
+        LOAD_PATHS: process.env.LOAD_PATHS ?? '/health/ready',
+        LOAD_CONCURRENCY: process.env.LOAD_CONCURRENCY ?? '20',
+        LOAD_DURATION_SECONDS: process.env.LOAD_DURATION_SECONDS ?? '20',
+        // A STARTING point, not a calibrated gate, and loose enough that it
+        // should be described honestly: 2000ms catches a hot path that has
+        // gone seconds slow or that errors under concurrency. It will NOT
+        // catch a 3x regression from 50ms to 150ms.
+        //
+        // Calibrate after the first green run. The harness prints p95 in its
+        // JSON summary, so take the observed value against the real gateway
+        // and set LOAD_MAX_P95_MS to roughly 3x it, then tighten as the
+        // number settles — the same ratchet idea as strict-null-baseline.json.
+        //
+        // Do not tighten past what a shared runner can hold. A flaky gate
+        // that people rerun until it passes is worse than no gate, because it
+        // teaches everyone to ignore the signal it exists to give.
+        LOAD_MAX_P95_MS: process.env.LOAD_MAX_P95_MS ?? '2000',
+        LOAD_MAX_ERROR_RATE: process.env.LOAD_MAX_ERROR_RATE ?? '0.01',
+        LOAD_MIN_RPS: process.env.LOAD_MIN_RPS ?? '20',
+      },
+    });
+  }
 } catch (error) {
   exitCode = 1;
   process.stderr.write(


### PR DESCRIPTION
The harness has existed since the start and has never sent a request in
CI. `test:load:check` runs with LOAD_DRY_RUN=1: it validates
configuration and exits. So nothing has ever measured whether a change
made a hot path slower, and a several-fold regression would have reached
production unremarked.

It runs inside the e2e run rather than as its own job, because that is
the only point where the stack is already standing — same isolated
Postgres and Redis on 15432/16379, same gateway on 13000, torn down by
the same `finally`. A separate job would rebuild all of it to measure
the same thing, and would double the infrastructure that can fail.

Probes /health/ready, not /health. Readiness touches the database and
Redis, so it measures the path a real request depends on; a liveness
handler returns a constant and stays fast no matter what regressed.

Opt-in via E2E_LOAD so a local `npm run test:e2e` does not get slower by
default. Adds ~20s to the test job and no new infrastructure.

## On the thresholds

They are a starting point and the comments say so rather than implying a
calibrated gate. 2000ms p95 catches a hot path that has gone seconds
slow or that errors under concurrency. It will NOT catch 50ms becoming
150ms.

Calibrating needs a number nobody has yet — the real p95 of this gateway
on a hosted runner. The first green run prints it, and every value is
overridable from the workflow, so tightening is a one-line change. The
alternative was inventing a threshold and finding out it was flaky
during someone else's release.

Verified against a real server, both directions:

  healthy (0ms)      p95 4.3ms, 7620 rps, exit 0
  regressed (2.5s)   "p95 2535.7ms exceeded 2000ms; throughput 7.94 rps
                      was below 20 rps", non-zero exit

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
