### PR TITLE
ops: deploy the five internal services from their images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -644,33 +644,37 @@ jobs:
       # a service does not become active. These are the service names shown in
       # Railway Architecture; GitHub prefixes deployment labels separately.
       - name: Deploy auth service
-        run: scripts/ci/railway-up.sh "Auth Service"
+        run: scripts/ci/railway-deploy-from-source.sh "Auth Service"
 
       - name: Deploy user service
-        run: scripts/ci/railway-up.sh "User Service"
+        run: scripts/ci/railway-deploy-from-source.sh "User Service"
 
       - name: Deploy resume builder service
-        run: scripts/ci/railway-up.sh "Resume Builder Service"
+        run: scripts/ci/railway-deploy-from-source.sh "Resume Builder Service"
 
       - name: Deploy chat service
-        run: scripts/ci/railway-up.sh "Chat Service"
+        run: scripts/ci/railway-deploy-from-source.sh "Chat Service"
 
       - name: Deploy job service
-        run: scripts/ci/railway-up.sh "Job Service"
+        run: scripts/ci/railway-deploy-from-source.sh "Job Service"
 
-      # CANARY — the only service on the image path. The other ten still
-      # rebuild via `railway up`, deliberately: converting all eleven at once is
-      # how #78 failed, and this one is the safest to be wrong about because
-      # nothing in the gateway request path calls into it.
+      # Was the canary, and shipped three clean releases on the image path
+      # before the five internal services above joined it. The API Gateway and
+      # the four monitoring services are still rebuilt by `railway up` —
+      # converting everything at once is how #78 failed, and the gateway is the
+      # one service where being wrong is immediately user-visible, so it goes
+      # last and on its own.
       #
-      # Its source was pointed at :main by hand, with account credentials. The
-      # project token used here cannot change a source (that IS what broke #78)
-      # but it can deploy, which is the whole basis of this approach.
+      # Every source here was pointed at :main by hand, with account
+      # credentials. The project token used by this job cannot change a source
+      # (that IS what broke #78) but it can deploy, which is the whole basis of
+      # this approach.
       #
-      # If this misbehaves, the fallback is one dashboard change — set the
-      # source back to the repo with builder RAILPACK and dockerfilePath
-      # /apps/notification-service/Dockerfile — and revert this step to
-      # `scripts/ci/railway-up.sh "Notification Service"`.
+      # Fallback for any of these six: set the source back to the repo in the
+      # Railway dashboard with builder RAILPACK and dockerfilePath
+      # /apps/<service>/Dockerfile, and revert that step to
+      # `scripts/ci/railway-up.sh "<Service Name>"`. Per service, no coupling
+      # between them.
       - name: Deploy notification service
         run: scripts/ci/railway-deploy-from-source.sh "Notification Service"
 

--- a/scripts/ci/check-infra-drift.mjs
+++ b/scripts/ci/check-infra-drift.mjs
@@ -165,6 +165,12 @@ if (!watchdog) {
 // railway-up.sh would fail this check, which is the correct direction to be
 // wrong in.
 const IMAGE_SOURCED = {
+  'Auth Service': 'ghcr.io/rithybondeth/apsaratalent-auth-service',
+  'User Service': 'ghcr.io/rithybondeth/apsaratalent-user-service',
+  'Resume Builder Service':
+    'ghcr.io/rithybondeth/apsaratalent-resume-builder-service',
+  'Chat Service': 'ghcr.io/rithybondeth/apsaratalent-chat-service',
+  'Job Service': 'ghcr.io/rithybondeth/apsaratalent-job-service',
   'Notification Service':
     'ghcr.io/rithybondeth/apsaratalent-notification-service',
 };


### PR DESCRIPTION
Extends the canary. Auth, User, Resume Builder, Chat and Job now deploy
the image the containers job built and scanned, rather than having
Railway rebuild from source.

Notification Service shipped three clean releases on this path first,
including one with no git-triggered rebuild racing it, which is the
evidence this batch is based on.

## Scope

The API Gateway and the four monitoring services still use `railway up`.
The gateway is deliberately last and on its own: it is the only service
where being wrong is immediately user-visible. Converting everything at
once is how #78 failed.

## What changed outside this repo

All five sources were pointed at :main by hand with account credentials.
Verified before the change that every :main tag resolves to the same
digest as the current release (cf3ad353), so no service is being pointed
at an image older than what it is already running.

Captured for reversal: all five were builder RAILPACK, dockerfilePath
/apps/<service>/Dockerfile, source.repo RithyBondeth/ApsaraTalent-Api,
rootDirectory null.

## The drift check will fail until this is released

check-infra-drift.mjs now expects six image-sourced services and asserts
what actually RAN, not what is configured. Right now those five last
deployed from source — the sources changed, the deployments have not
caught up — so it reports drift, correctly.

Merging this fixes it: the release deploys all five from their images
and the next check passes. But do not leave this merged-and-unreleased
overnight, or the 02:00 UTC scheduled run will fail on a state that is
only transient.

Same run also confirms #95 holding: "no git-triggered deployments in
the last 10 per service — CI is the only path to production".

## Expected effect

Those five cost 8.76m of the 11.9m deploy job. On the image path
Notification Service takes 0.20m. If they behave the same, the deploy
job should land near 3-4m, down from 17m this morning.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
