### PR TITLE
ops: deploy the API gateway from its image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -691,7 +691,7 @@ jobs:
         run: scripts/ci/railway-up.sh grafana
 
       - name: Deploy API gateway
-        run: scripts/ci/railway-up.sh "API Gateway"
+        run: scripts/ci/railway-deploy-from-source.sh "API Gateway"
 
       # EXPECTED_RELEASE makes this prove the NEW revision is serving. Without
       # it, a `railway up` that silently changed nothing left the previous

--- a/scripts/ci/check-infra-drift.mjs
+++ b/scripts/ci/check-infra-drift.mjs
@@ -165,6 +165,7 @@ if (!watchdog) {
 // railway-up.sh would fail this check, which is the correct direction to be
 // wrong in.
 const IMAGE_SOURCED = {
+  'API Gateway': 'ghcr.io/rithybondeth/apsaratalent-api-gateway',
   'Auth Service': 'ghcr.io/rithybondeth/apsaratalent-auth-service',
   'User Service': 'ghcr.io/rithybondeth/apsaratalent-user-service',
   'Resume Builder Service':


### PR DESCRIPTION
The last application service, and the one where being wrong is
immediately user-visible — so it went last and on its own, after the
other six had shipped a release together.

## Checked before touching it, because it is not like the others

The gateway has a volume, `apsaratalent-api-volume` mounted at
/app/storage, which is where uploaded chat files live. Volumes attach to
the SERVICE, not to its source, and it is still attached after the
change — verified, not assumed. Losing it would have silently orphaned
every uploaded file.

Its :main tag was confirmed to resolve to the same digest as the current
release (ae4748eb -> sha256:cb39f8c2aa23) so it is not being pointed at
anything older than what it is already running.

## railway.toml turns out never to have applied

The worry with an image source is that Railway can no longer read
railway.toml, since there is no repo to read it from. It makes no
difference here, because it was never being read:

  Auth (already image)   overlap=null drain=null retries=10 ON_FAILURE
  Gateway (repo source)  overlap=null drain=null retries=10 ON_FAILURE
  prometheus (repo)      overlap=null drain=null retries=10 ON_FAILURE

railway.toml asks for overlapSeconds=20 and drainingSeconds=30. Neither
is set on any service, converted or not, because railwayConfigFile is
null everywhere — Railway only reads a config file when a service is
told where it is, exactly as railway.toml's own comment says.

So this change loses nothing. But those two settings are what make a
deploy overlap the old instance instead of dropping connections, and
they have never been in effect. Worth its own change; noted rather than
folded in here.

## State after this

Seven of eleven services deploy the scanned artifact. The four
monitoring services still rebuild — they are thin config layers over
upstream images and cost 1.61m combined, so they are the low-value tail
rather than the next obvious step.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
