### PR TITLE
ops: apply zero-downtime deploys, and calibrate the load gate

### DIFF
--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -29,12 +29,26 @@ Run it locally the same way CI does:
 E2E_LOAD=1 npm run test:e2e
 ```
 
-**The thresholds are a starting point, not a calibrated gate.** `LOAD_MAX_P95_MS`
-is 2000ms, which catches a hot path that has gone seconds slow or that errors
-under concurrency — it will not catch a regression from 50ms to 150ms. After the
-first green run, take the p95 the harness prints and set the threshold to
-roughly 3x it, then tighten as the number settles. Every value is overridable
-from the workflow, so calibrating is a one-line change.
+`LOAD_MAX_P95_MS` is **500ms**, calibrated from three consecutive hosted-runner
+releases rather than guessed:
+
+| run | p95 | errors |
+| --- | --- | --- |
+| 1 | 111.0ms | 0.37% |
+| 2 | 169.1ms | 0.26% |
+| 3 | 110.4ms | 0 |
+
+500ms is roughly 3x the worst of those. The spread between 110ms and 169ms under
+identical conditions is why the multiple is 3x and not 1.5x — a shared runner
+varies by half again on its own.
+
+**Know what this endpoint costs before raising concurrency.** `/health/ready`
+pings the database, Redis *and* all six internal services over TCP, so every
+request fans out to eight dependencies. At ~287 rps that is ~2,300 backend
+operations per second, and the occasional 503 in the runs above is that fan-out
+saturating rather than an application fault — production probes this endpoint
+every 15-30 seconds, not 287 times a second. The 1% error tolerance stays a real
+gate: it is what would catch readiness genuinely breaking.
 
 Do not tighten past what a shared runner can hold. A flaky gate is worse than no
 gate: people rerun it until it passes, and learn to ignore the one signal it

--- a/railway.toml
+++ b/railway.toml
@@ -46,6 +46,15 @@ builder = "DOCKERFILE"
 # - blackbox-exporter -> railway/blackbox-exporter.toml
 # - Grafana           -> railway/grafana.toml
 
+# NOTE: Railway does not read this section. `railwayConfigFile` is unset on
+# every service, and seven services now deploy from a GHCR image where there is
+# no repository to read a config file from at all. Until 2026-08-09 that meant
+# overlapSeconds and drainingSeconds had never applied to anything — deploys
+# replaced an instance before it was serving and cut in-flight requests.
+#
+# They are now set directly on each service instead, and asserted by
+# scripts/ci/check-infra-drift.mjs so they cannot silently revert. This block is
+# kept as the documented intent; the drift check is what enforces it.
 [deploy]
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10

--- a/scripts/ci/check-infra-drift.mjs
+++ b/scripts/ci/check-infra-drift.mjs
@@ -190,6 +190,75 @@ const TRIGGERLESS_SERVICES = [
   'blackbox-exporter',
 ];
 
+// Zero-downtime settings. railway.toml has always asked for these, and until
+// 2026-08-09 not one service had them: `railwayConfigFile` is null on every
+// service, so Railway never read that file — and now that seven services deploy
+// from an image there is no repo for it to read at all. They are set directly
+// on each service instead, which makes them dashboard-only state and therefore
+// this script's business.
+//
+// Without overlapSeconds a new instance replaces the old one before it is
+// serving, and without drainingSeconds in-flight requests are cut rather than
+// finished. Both are silent: deploys look identical either way, and the only
+// evidence is requests failing during a release.
+const ZERO_DOWNTIME_SERVICES = [
+  'API Gateway',
+  'Auth Service',
+  'User Service',
+  'Resume Builder Service',
+  'Chat Service',
+  'Job Service',
+  'Notification Service',
+];
+const EXPECTED_OVERLAP_SECONDS = 20;
+const EXPECTED_DRAINING_SECONDS = 30;
+
+// These two are the only place this script needs Railway's own identifiers.
+// Resolved from the project rather than hard-coded, so a recreated service
+// cannot leave a stale UUID silently checking nothing.
+const PROJECT_ID =
+  process.env.RAILWAY_PROJECT_ID || '25a2e450-b6e7-430c-868c-5adb27de4d2c';
+const ENVIRONMENT_ID =
+  process.env.RAILWAY_ENV_ID || 'db8b2f83-a515-4555-986a-3c79c2bb052c';
+
+function railwayApi(query, variables) {
+  const result = spawnSync(
+    'railway',
+    ['api', query, '--variables', JSON.stringify(variables), '--compact'],
+    { encoding: 'utf8', timeout: 60_000 },
+  );
+  const start = result.stdout.search(/[[{]/);
+  if (start === -1) {
+    throw new Error(
+      `railway api returned no JSON: ${(result.stderr || result.stdout || '').slice(0, 200)}`,
+    );
+  }
+  const body = JSON.parse(result.stdout.slice(start));
+  if (body.errors) {
+    throw new Error(
+      `railway api: ${body.errors
+        .map((e) => e.message)
+        .join('; ')
+        .slice(0, 200)}`,
+    );
+  }
+  return body.data;
+}
+
+const serviceIds = new Map(
+  railwayApi(
+    `query ($id: String!) { project(id: $id) { services { edges { node { id name } } } } }`,
+    { id: PROJECT_ID },
+  ).project.services.edges.map((edge) => [edge.node.name, edge.node.id]),
+);
+
+const GRACEFUL_QUERY = `query ($serviceId: String!, $environmentId: String!) {
+  serviceInstance(serviceId: $serviceId, environmentId: $environmentId) {
+    overlapSeconds
+    drainingSeconds
+  }
+}`;
+
 // Asserts what actually RAN, not what is configured. A configured source that
 // has never deployed proves nothing, and the deployment record is the same
 // place the rollback path reads from.
@@ -298,6 +367,40 @@ if (gitTriggered.length) {
 } else {
   notes.push(
     `no git-triggered deployments in the last ${GIT_TRIGGER_WINDOW} per service — CI is the only path to production`,
+  );
+}
+
+const missingZeroDowntime = [];
+for (const service of ZERO_DOWNTIME_SERVICES) {
+  const serviceId = serviceIds.get(service);
+  const instance = serviceId
+    ? railwayApi(GRACEFUL_QUERY, { serviceId, environmentId: ENVIRONMENT_ID })
+        .serviceInstance
+    : null;
+
+  if (!instance) {
+    missingZeroDowntime.push(`${service} (could not be read)`);
+  } else if (
+    instance.overlapSeconds !== EXPECTED_OVERLAP_SECONDS ||
+    instance.drainingSeconds !== EXPECTED_DRAINING_SECONDS
+  ) {
+    missingZeroDowntime.push(
+      `${service} (overlap=${instance.overlapSeconds}, draining=${instance.drainingSeconds})`,
+    );
+  }
+}
+
+if (missingZeroDowntime.length) {
+  failures.push(
+    `Zero-downtime settings are wrong on: ${missingZeroDowntime.join('; ')}. ` +
+      `Expected overlapSeconds=${EXPECTED_OVERLAP_SECONDS} and ` +
+      `drainingSeconds=${EXPECTED_DRAINING_SECONDS}. Without them a release ` +
+      `replaces an instance before it is serving and cuts in-flight requests, ` +
+      `which looks identical to a healthy deploy from the outside.`,
+  );
+} else {
+  notes.push(
+    `zero-downtime: overlap=${EXPECTED_OVERLAP_SECONDS}s draining=${EXPECTED_DRAINING_SECONDS}s on all ${ZERO_DOWNTIME_SERVICES.length} application services`,
   );
 }
 

--- a/test/e2e/run-e2e.mjs
+++ b/test/e2e/run-e2e.mjs
@@ -331,20 +331,31 @@ try {
         LOAD_PATHS: process.env.LOAD_PATHS ?? '/health/ready',
         LOAD_CONCURRENCY: process.env.LOAD_CONCURRENCY ?? '20',
         LOAD_DURATION_SECONDS: process.env.LOAD_DURATION_SECONDS ?? '20',
-        // A STARTING point, not a calibrated gate, and loose enough that it
-        // should be described honestly: 2000ms catches a hot path that has
-        // gone seconds slow or that errors under concurrency. It will NOT
-        // catch a 3x regression from 50ms to 150ms.
+        // Calibrated from three consecutive hosted-runner releases rather
+        // than guessed:
         //
-        // Calibrate after the first green run. The harness prints p95 in its
-        // JSON summary, so take the observed value against the real gateway
-        // and set LOAD_MAX_P95_MS to roughly 3x it, then tighten as the
-        // number settles — the same ratchet idea as strict-null-baseline.json.
+        //   p95 111.0ms   0.37% errors
+        //   p95 169.1ms   0.26% errors
+        //   p95 110.4ms   0    errors
         //
-        // Do not tighten past what a shared runner can hold. A flaky gate
-        // that people rerun until it passes is worse than no gate, because it
-        // teaches everyone to ignore the signal it exists to give.
-        LOAD_MAX_P95_MS: process.env.LOAD_MAX_P95_MS ?? '2000',
+        // 500ms is ~3x the worst of those. The spread between 110ms and 169ms
+        // in identical conditions is why it is 3x and not 1.5x: a shared
+        // runner varies by half again on its own, and a gate that fails on
+        // runner weather is one people rerun until it passes, which teaches
+        // everyone to ignore the signal it exists to give.
+        //
+        // Down from the 2000ms placeholder, which had an 18x margin and would
+        // have caught almost nothing.
+        //
+        // Note what this endpoint costs before loosening concurrency:
+        // /health/ready pings the database, Redis AND all six internal
+        // services over TCP, so every request fans out to eight dependencies.
+        // At ~287 rps that is ~2,300 backend operations per second, and the
+        // occasional 503 in the runs above is that fan-out saturating — not
+        // an application fault. Production probes this endpoint every 15-30s.
+        // The 1% error tolerance is deliberately kept as a real gate: it is
+        // what would catch readiness genuinely breaking.
+        LOAD_MAX_P95_MS: process.env.LOAD_MAX_P95_MS ?? '500',
         LOAD_MAX_ERROR_RATE: process.env.LOAD_MAX_ERROR_RATE ?? '0.01',
         LOAD_MIN_RPS: process.env.LOAD_MIN_RPS ?? '20',
       },


### PR DESCRIPTION
Three things, all from measurements taken since the image conversion.

## overlapSeconds and drainingSeconds have never applied

railway.toml has asked for overlapSeconds=20 and drainingSeconds=30
since it was written. Not one service had them:

  Auth (image source)    overlap=null drain=null
  Gateway (repo source)  overlap=null drain=null
  prometheus (repo)      overlap=null drain=null

`railwayConfigFile` is null on every service, so Railway never read that
file — and now that seven services deploy from a GHCR image there is no
repository for it to read one from at all. Without overlapSeconds a new
instance replaces the old before it is serving; without drainingSeconds
in-flight requests are cut rather than finished. Both are invisible: the
deploy looks identical either way, and the only evidence is requests
failing during a release.

Now set directly on all seven application services, and asserted by
check-infra-drift.mjs so they cannot silently revert — dashboard-only
state is exactly what that script is for. railway.toml keeps the block
as documented intent with a note that the drift check is the enforcement.

The drift check now resolves service ids from the project rather than
hard-coding them, so a recreated service cannot leave a stale UUID
quietly checking nothing.

## Load gate calibrated: 2000ms -> 500ms

Three consecutive hosted-runner releases:

  p95 111.0ms   0.37% errors
  p95 169.1ms   0.26% errors
  p95 110.4ms   0    errors

500ms is ~3x the worst. The spread between 110ms and 169ms under
identical conditions is why it is 3x and not 1.5x. The old 2000ms had an
18x margin and would have caught almost nothing.

## The 503s are the test, not the application

/health/ready pings the database, Redis AND all six internal services
over TCP — eight dependencies per request. At ~287 rps that is ~2,300
backend operations per second, and the intermittent 503s are that
fan-out saturating. Production probes this endpoint every 15-30 seconds.

Documented rather than tuned away, and the 1% error tolerance is kept as
a real gate: it is what would catch readiness genuinely breaking.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
