### PR TITLE
ops: deploy the four monitoring services from their images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,10 +133,10 @@ jobs:
       # validates the harness configuration but sends no requests, so until now
       # nothing has ever measured whether a change made a hot path slower.
       #
-      # Thresholds are deliberately loose (see test/e2e/run-e2e.mjs): a shared
-      # runner cannot support a tight latency gate without becoming flaky, and a
-      # gate people rerun until it passes is worse than no gate. This catches a
-      # hot path becoming several times slower or erroring under concurrency.
+      # The p95 threshold is calibrated from three hosted-runner releases (see
+      # test/e2e/run-e2e.mjs). It is 3x the worst observed, because a shared runner
+      # varies by half again on its own and a gate that fails on runner weather is
+      # one people rerun until it passes.
       - name: Run isolated end-to-end tests and load phase
         run: npm run test:e2e
         env:
@@ -679,16 +679,16 @@ jobs:
         run: scripts/ci/railway-deploy-from-source.sh "Notification Service"
 
       - name: Deploy Alertmanager
-        run: scripts/ci/railway-up.sh alertmanager
+        run: scripts/ci/railway-deploy-from-source.sh alertmanager
 
       - name: Deploy blackbox exporter
-        run: scripts/ci/railway-up.sh blackbox-exporter
+        run: scripts/ci/railway-deploy-from-source.sh blackbox-exporter
 
       - name: Deploy Prometheus
-        run: scripts/ci/railway-up.sh prometheus
+        run: scripts/ci/railway-deploy-from-source.sh prometheus
 
       - name: Deploy Grafana
-        run: scripts/ci/railway-up.sh grafana
+        run: scripts/ci/railway-deploy-from-source.sh grafana
 
       - name: Deploy API gateway
         run: scripts/ci/railway-deploy-from-source.sh "API Gateway"

--- a/scripts/ci/check-infra-drift.mjs
+++ b/scripts/ci/check-infra-drift.mjs
@@ -174,6 +174,10 @@ const IMAGE_SOURCED = {
   'Job Service': 'ghcr.io/rithybondeth/apsaratalent-job-service',
   'Notification Service':
     'ghcr.io/rithybondeth/apsaratalent-notification-service',
+  alertmanager: 'ghcr.io/rithybondeth/apsaratalent-monitoring-alertmanager',
+  'blackbox-exporter': 'ghcr.io/rithybondeth/apsaratalent-monitoring-blackbox',
+  prometheus: 'ghcr.io/rithybondeth/apsaratalent-monitoring-prometheus',
+  grafana: 'ghcr.io/rithybondeth/apsaratalent-monitoring-grafana',
 };
 
 // The services that had a GitHub deployment trigger before 2026-08-09.


### PR DESCRIPTION
Completes build-once-deploy-many. All eleven services now run the image
CI built and scanned; nothing is rebuilt by Railway.

## Why this one waited

These four were held back deliberately. Unlike the seven application
services, which had `source.repo` set, prometheus and grafana had
`source: null` — no configured source at all, deployed by `railway up`
uploading the directory. Reverting from an image was therefore an
unknown operation on the stack you need working to diagnose a bad
deploy, for a payoff of about 1.2 minutes a release. Not a trade worth
making on an assumption.

So it was measured first, on a throwaway service created in the same
`source: null` state:

  initial                        source: null
  set image                      {"image":"nginx:1.29-alpine","repo":null}
  revert {"source":{"image":null}} {"image":null,"repo":null}

The revert works and lands functionally where these services started —
no image, no repo, which is what `railway up` needs. Probe service
deleted; project verified back to its original 12.

## Volumes

All three monitoring volumes verified still attached after the change:
alertmanager-volume -> /alertmanager, grafana-volume ->
/var/lib/grafana, prometheus-volume -> /prometheus. Volumes bind to the
service, not its source, but Grafana losing its volume would mean losing
the dashboards.

## Drift

check-infra-drift.mjs now asserts all eleven, so a service reverting to
a source build is caught rather than silently shipping an unscanned
rebuild.

Also corrects a comment in deploy.yml that still described the load
thresholds as "deliberately loose" — they were calibrated in #99.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
