### PR TITLE
fix(ci): stop the load phase saturating the endpoint it measures

### DIFF
--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -42,13 +42,27 @@ releases rather than guessed:
 identical conditions is why the multiple is 3x and not 1.5x — a shared runner
 varies by half again on its own.
 
-**Know what this endpoint costs before raising concurrency.** `/health/ready`
-pings the database, Redis *and* all six internal services over TCP, so every
-request fans out to eight dependencies. At ~287 rps that is ~2,300 backend
-operations per second, and the occasional 503 in the runs above is that fan-out
-saturating rather than an application fault — production probes this endpoint
-every 15-30 seconds, not 287 times a second. The 1% error tolerance stays a real
-gate: it is what would catch readiness genuinely breaking.
+**Concurrency is 5, and that is deliberate.** `/health/ready` pings the database,
+Redis *and* all six internal services over TCP, so every request fans out to
+eight dependencies. It ran at concurrency 20 for five releases, which was ~2,300
+backend operations per second, and the internal pings intermittently timed out:
+
+| run | error rate |
+| --- | --- |
+| 1 | 0.37% |
+| 2 | 0.26% |
+| 3 | 0% |
+| 4 | 0.26% |
+| 5 | **3.3%** — failed the release |
+
+The 1% tolerance sits inside that spread, so run 5 failed a release for runner
+contention rather than for anything in the code. Concurrency 5 keeps the real
+dependency fan-out in the measurement — the reason this endpoint was chosen —
+while staying off the saturation cliff. Nothing in production probes readiness
+more than every 15-30 seconds, so 20 was never a realistic shape of load.
+
+The 1% error tolerance stays a real gate. At this concurrency a 503 should mean
+readiness is genuinely broken.
 
 Do not tighten past what a shared runner can hold. A flaky gate is worse than no
 gate: people rerun it until it passes, and learn to ignore the one signal it

--- a/test/e2e/run-e2e.mjs
+++ b/test/e2e/run-e2e.mjs
@@ -329,7 +329,7 @@ try {
         // Redis, so this measures the path a real request depends on rather
         // than a constant handler that would stay fast whatever regressed.
         LOAD_PATHS: process.env.LOAD_PATHS ?? '/health/ready',
-        LOAD_CONCURRENCY: process.env.LOAD_CONCURRENCY ?? '20',
+        LOAD_CONCURRENCY: process.env.LOAD_CONCURRENCY ?? '5',
         LOAD_DURATION_SECONDS: process.env.LOAD_DURATION_SECONDS ?? '20',
         // Calibrated from three consecutive hosted-runner releases rather
         // than guessed:
@@ -347,14 +347,34 @@ try {
         // Down from the 2000ms placeholder, which had an 18x margin and would
         // have caught almost nothing.
         //
-        // Note what this endpoint costs before loosening concurrency:
+        // Concurrency is 5, not 20, and that is this step's first lesson.
+        //
         // /health/ready pings the database, Redis AND all six internal
-        // services over TCP, so every request fans out to eight dependencies.
-        // At ~287 rps that is ~2,300 backend operations per second, and the
-        // occasional 503 in the runs above is that fan-out saturating — not
-        // an application fault. Production probes this endpoint every 15-30s.
-        // The 1% error tolerance is deliberately kept as a real gate: it is
-        // what would catch readiness genuinely breaking.
+        // services over TCP — eight dependencies per request. At concurrency
+        // 20 that was ~2,300 backend operations per second, and the internal
+        // pings intermittently timed out and returned 503. Error rate over
+        // five consecutive runs:
+        //
+        //   0.37%   0.26%   0%   0.26%   3.3%
+        //
+        // The 1% tolerance sits inside that spread, so the fifth run failed a
+        // release for runner weather. Documenting the cause was not enough —
+        // a gate that fails on noise is one people rerun until it passes,
+        // which is precisely what this was written to avoid being.
+        //
+        // Concurrency 5 keeps the endpoint's real dependency fan-out in the
+        // measurement, which is why this target was chosen, while staying off
+        // the saturation cliff. Nothing in production probes readiness more
+        // than every 15-30 seconds, so 20 was never a realistic shape of
+        // load — it was just a bigger number.
+        //
+        // p95 will fall well under the 500ms ceiling at this concurrency, so
+        // that stays as a generous upper bound rather than being re-tightened
+        // on a single sample.
+        //
+        // The 1% error tolerance stays a real gate. At this concurrency a 503
+        // should mean readiness is genuinely broken, not that the runner was
+        // busy.
         LOAD_MAX_P95_MS: process.env.LOAD_MAX_P95_MS ?? '500',
         LOAD_MAX_ERROR_RATE: process.env.LOAD_MAX_ERROR_RATE ?? '0.01',
         LOAD_MIN_RPS: process.env.LOAD_MIN_RPS ?? '20',


### PR DESCRIPTION
The load phase failed a release on error rate, not latency: 146 of 4421
requests returned 503, an error rate of 3.3% against the 1% gate. p95
was 143.7ms against a 500ms ceiling, so latency was never the problem.

Error rate across the five runs since this landed:

  0.37%   0.26%   0%   0.26%   3.3%

The 1% tolerance sits inside that spread. This was a flaky gate, and it
failed a release for runner contention rather than for anything in the
code.

The cause was known and written down when the step was added:
/health/ready pings the database, Redis and all six internal services
over TCP, so every request fans out to eight dependencies, and at
concurrency 20 that is ~2,300 backend operations per second. Documenting
it was not a fix. A gate that fails on noise is one people rerun until it
passes, which is the exact failure mode the original comment warned
against — and it was written that way anyway.

Concurrency 20 -> 5. That keeps the dependency fan-out in the
measurement, which is why this endpoint was chosen over a constant
liveness handler, while staying off the saturation cliff. Nothing in
production probes readiness more than every 15-30 seconds, so 20 was
never a realistic shape of load; it was a bigger number.

p95 falls well under 500ms at this concurrency, so the ceiling stays as
a generous upper bound rather than being re-tightened on one sample.
The 1% error tolerance stays a real gate: at concurrency 5, a 503 should
mean readiness is genuinely broken.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
