### PR TITLE
fix(db): drop _rehearsal_probe, which reached production by accident

### DIFF
--- a/migrations/1786400000000-DropRehearsalProbe.ts
+++ b/migrations/1786400000000-DropRehearsalProbe.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Removes `_rehearsal_probe`, which reached production by accident.
+ *
+ * It was created by RehearsalProbe1786300000000 on a branch named
+ * `scratch/DO-NOT-MERGE-rehearsal-probe`, whose only purpose was to make the
+ * migration rehearsal execute its forward/reverse/re-apply sequence — a path
+ * that had never run, because every release until then had zero pending
+ * migrations. That branch was merged as #103 and the release applied it.
+ *
+ * It did work: all three phases ran and passed, so the rehearsal is now proven
+ * rather than assumed. This is the cleanup for the way it happened.
+ *
+ * Forward-fixed rather than reverted. `migration:revert` against production is
+ * a manual operation on the live database; a migration is the same change
+ * carried by the pipeline that rehearses it first.
+ *
+ * The table was empty and referenced by nothing — no entity, no query, no
+ * foreign key. Dropping it cannot affect the application.
+ */
+export class DropRehearsalProbe1786400000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "_rehearsal_probe"`);
+  }
+
+  // Symmetric on purpose. Recreating an empty throwaway table costs nothing,
+  // and keeping this reversible means the rehearsal exercises all three of its
+  // phases on the way in rather than skipping the reverse one.
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE IF NOT EXISTS "_rehearsal_probe" ("id" integer PRIMARY KEY)`,
+    );
+  }
+}


### PR DESCRIPTION
`scratch/DO-NOT-MERGE-rehearsal-probe` existed to make the migration
rehearsal execute its forward/reverse/re-apply sequence — a path that
had never run, because every release since the rehearsal landed had zero
pending migrations. The branch was named to prevent exactly this and had
no pull request. It was merged as #103, and the release applied it.

It did work. All three phases ran against a copy-on-write branch of
production and passed:

  ok  2.8s  Forward: applying 1 migration(s) to real data
  ok  2.6s  Reverse: reverting RehearsalProbe1786300000000
  ok  2.6s  Re-apply: running the forward path a second time

So the control the release path most depends on is now proven rather
than assumed. This is the cleanup for the way it got proven.

Forward-fixed rather than reverted: `migration:revert` against
production is a manual operation on the live database, whereas a
migration is the same change carried by the pipeline that rehearses it
first. The RehearsalProbe migration stays in history — it ran, and
deleting the file would not remove its row from the migrations table.

The table was empty and referenced by nothing: no entity, no query, no
foreign key. Verified by grep across apps/ and libs/.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
