### PR TITLE
fix(chat): attribute calls and notifications to the actual sender

### DIFF
--- a/apps/api-gateway/src/chat/services/chat-notification.service.ts
+++ b/apps/api-gateway/src/chat/services/chat-notification.service.ts
@@ -34,7 +34,12 @@ export class ChatNotificationService implements IChatNotificationService {
       const user = await rpcCall<UserResponseDTO>(
         this.userServiceClient,
         USER_SERVICE.ACTIONS.FIND_ONE_BY_ID,
-        userId,
+        // Must be the DTO, not a bare string: the handler destructures
+        // `{ userId }`, so a string yielded `undefined`, and `findOne` with an
+        // undefined id drops the condition and returns whichever user happens
+        // to be first. Every incoming call and chat notification was therefore
+        // attributed to the same arbitrary person.
+        { userId },
       );
       if (!user) return { name: 'Unknown', avatar: CHAT.DEFAULT_AVATAR_PATH };
 

--- a/apps/api-gateway/src/chat/services/chat-support-services.spec.ts
+++ b/apps/api-gateway/src/chat/services/chat-support-services.spec.ts
@@ -135,6 +135,21 @@ describe('chat support services', () => {
       );
     });
 
+    it('asks user-service with the DTO shape its handler destructures', async () => {
+      // Sending a bare string made the handler read `undefined` for the id.
+      // `findOne` drops an undefined condition and returns whichever user is
+      // first, so every incoming call and chat notification was attributed to
+      // the same arbitrary person. The mock never checked the payload, which
+      // is why the suite stayed green through it.
+      users.send.mockReturnValueOnce(of({ company: { name: 'Apsara' } }));
+
+      await service.getCallerProfile('caller-42');
+
+      const [, payload] = users.send.mock.calls[0];
+      expect(payload).toEqual({ userId: 'caller-42' });
+      expect(typeof payload).not.toBe('string');
+    });
+
     it('covers missing, email, username, and default profile fallbacks', async () => {
       users.send
         .mockReturnValueOnce(of(null))

--- a/apps/user-service/src/users/services/user.service.ts
+++ b/apps/user-service/src/users/services/user.service.ts
@@ -177,7 +177,19 @@ export class UserService implements IUserService, OnModuleInit {
   }
 
   async findOneUserByID(userIdDTO: UserIdDTO): Promise<UserResponseDTO> {
-    const { userId } = userIdDTO;
+    const { userId } = userIdDTO ?? {};
+
+    // A missing id must fail loudly. `findOne({ where: { id: undefined } })`
+    // drops the condition and returns an arbitrary row, so a caller that sent
+    // the wrong payload shape silently received someone else's account — and
+    // it was then cached under a shared key for everyone.
+    if (!userId) {
+      throw new RpcException({
+        statusCode: 400,
+        message: 'A user id is required.',
+      });
+    }
+
     const cacheKey = generateUserKey('detail', userId);
     const cached = await this.redisService.get<UserResponseDTO>(cacheKey);
 


### PR DESCRIPTION
Every incoming call showed the same name — "Sophea Chan" regardless of who was
calling — and chat notifications carried that name too.

## Cause

`getCallerProfile` sent the user id to user-service as a bare string:

```ts
rpcCall(client, FIND_ONE_BY_ID, userId)   // handler destructures { userId }
```

The handler destructures `{ userId }` from its payload, so a string yielded
`undefined`. `findOne({ where: { id: undefined } })` does not match nothing —
TypeORM drops the condition entirely and returns whichever row comes back
first. That row is "Sophea Chan", the first user in the table, so every caller
resolved to her:

```sql
SELECT ... FROM "user" LIMIT 1;   →  Sophea Chan
```

The result was then cached under `user:detail:undefined`, a key shared by every
lookup.

This was not limited to calls. `notifyChatMessage` uses the same function, so
chat notifications were attributed to the wrong sender as well.

The other two callers of `FIND_ONE_BY_ID` already passed `{ userId }`; this was
the only one that did not.

## Change

- The call site passes the DTO.
- `findOneUserByID` rejects a missing id with a 400 rather than answering with
  an arbitrary account, so a wrong payload shape can never again silently
  return someone else's profile.
- The spec mocked `users.send` without asserting what it was called with, which
  is why a string payload sailed through. It now checks the DTO shape.

## Verification

1276 unit tests, lint and typecheck clean, strict-null ratchet holding at 91.
Verified end to end: the server emits `callerName = Rithy Bondeth` for a call
from that account, and the browser modal renders it. Redis was flushed, since
the wrong profile had been cached under the shared key.