### PR TITLE
fix(db): let the backup actually fall back to the container client

### DIFF
--- a/scripts/db/backup-db.sh
+++ b/scripts/db/backup-db.sh
@@ -10,13 +10,25 @@
 #   DATABASE_URL="postgresql://..." ./scripts/db/backup-db.sh [output-directory]
 #
 # Requires either a local pg_dump, or Docker (the script falls back to running
-# pg_dump inside the same Postgres image used for e2e tests). The fallback also
-# sidesteps the most common failure here: pg_dump refuses to run against a
-# server NEWER than itself, and Neon upgrades faster than most laptops do.
+# pg_dump inside a Postgres image). The fallback exists to sidestep the most
+# common failure here: pg_dump refuses to run against a server NEWER than
+# itself, and Neon upgrades faster than most laptops — or GitHub runners — do.
+#
+# That fallback could not fire until 2026-08-21: it sat behind `elif`, so it was
+# reached only when NO local pg_dump existed. A GitHub runner ships one, so the
+# too-old client always won the branch and the nightly backup failed four nights
+# running (Neon 17.11 vs pg_dump 16.15) with the container that would have
+# worked sitting right there. The local client is now a preference rather than a
+# commitment: if it fails for any reason and Docker is available, the dump is
+# retried in the container.
 
 set -euo pipefail
 
-PG_IMAGE="pgvector/pgvector:pg16"
+# Must be >= the server's major version, because pg_dump cannot read a newer
+# server. Neon upgrades on their own schedule, so when a dump fails with
+# `server version mismatch`, take the server version from the error message and
+# bump this. (Neon was on 17.11 when this was last set.)
+PG_IMAGE="pgvector/pgvector:pg17"
 OUT_DIR="${1:-./backups}"
 
 if [ -z "${DATABASE_URL:-}" ]; then
@@ -53,18 +65,67 @@ cleanup_partial() {
 }
 trap 'cleanup_partial' ERR
 
+# pg_dump's stderr is captured rather than streamed so that a first-choice
+# failure can be explained instead of just retried, and so the version-mismatch
+# hint below has something to read.
+ERR_FILE="$(mktemp)"
+trap 'rm -f "$ERR_FILE"' EXIT
+
 # --format=custom is required for selective/parallel pg_restore later.
 # --no-owner/--no-privileges keep the dump portable across roles, which matters
 # when restoring into a fresh Neon branch or a local container.
 DUMP_ARGS=(--format=custom --no-owner --no-privileges --verbose)
 
-if command -v pg_dump >/dev/null 2>&1; then
-  pg_dump "$DIRECT_URL" "${DUMP_ARGS[@]}" > "$OUT_FILE"
-elif command -v docker >/dev/null 2>&1; then
+# The dump and the verification below must use the SAME client. A custom-format
+# archive written by pg_dump 17 cannot be read by pg_restore 16, so a mixed pair
+# fails at the verify step even when the dump itself was perfectly good.
+USED_DOCKER=0
+
+dump_locally() {
+  pg_dump "$DIRECT_URL" "${DUMP_ARGS[@]}" > "$OUT_FILE" 2>"$ERR_FILE"
+}
+
+dump_in_docker() {
   # --network host so a localhost/127.0.0.1 DATABASE_URL still resolves from
   # inside the container. Harmless for remote hosts like Neon.
   docker run --rm -i --network host "$PG_IMAGE" \
-    pg_dump "$DIRECT_URL" "${DUMP_ARGS[@]}" > "$OUT_FILE"
+    pg_dump "$DIRECT_URL" "${DUMP_ARGS[@]}" > "$OUT_FILE" 2>"$ERR_FILE"
+}
+
+# Whoever reads a failed nightly run should not have to work out what a bare
+# exit code meant, so name the one failure that has actually happened here.
+report_failure() {
+  cat "$ERR_FILE" >&2
+  if grep -q 'server version mismatch' "$ERR_FILE"; then
+    SERVER_MAJOR="$(sed -nE 's/.*server version: ([0-9]+).*/\1/p' "$ERR_FILE" | head -n1)"
+    echo "" >&2
+    echo "Every available pg_dump is older than the server. Set PG_IMAGE in this" >&2
+    echo "script to a Postgres ${SERVER_MAJOR:-<server-major>} image (it is currently ${PG_IMAGE})." >&2
+  fi
+  cleanup_partial
+  exit 1
+}
+
+HAVE_PG_DUMP=0
+if command -v pg_dump >/dev/null 2>&1; then HAVE_PG_DUMP=1; fi
+HAVE_DOCKER=0
+if command -v docker >/dev/null 2>&1; then HAVE_DOCKER=1; fi
+
+# The local client is tried first because it is faster and needs no daemon, but
+# a failure here is not fatal while Docker can still be asked.
+if [ "$HAVE_PG_DUMP" -eq 1 ] && dump_locally; then
+  echo "Dumped using the local pg_dump."
+elif [ "$HAVE_DOCKER" -eq 1 ]; then
+  if [ "$HAVE_PG_DUMP" -eq 1 ]; then
+    echo "Local pg_dump failed; retrying inside ${PG_IMAGE}. It said:" >&2
+    sed -n '1,3p' "$ERR_FILE" >&2
+  fi
+  USED_DOCKER=1
+  dump_in_docker || report_failure
+  echo "Dumped using pg_dump inside ${PG_IMAGE}."
+elif [ "$HAVE_PG_DUMP" -eq 1 ]; then
+  # The local client failed and there is no Docker to fall back to.
+  report_failure
 else
   echo "ERROR: neither pg_dump nor docker is available." >&2
   exit 1
@@ -73,7 +134,7 @@ fi
 # A dump that cannot be listed cannot be restored. Verifying now beats
 # discovering it during an incident.
 echo "Verifying dump is readable..."
-if command -v pg_restore >/dev/null 2>&1; then
+if [ "$USED_DOCKER" -eq 0 ] && command -v pg_restore >/dev/null 2>&1; then
   OBJECTS="$(pg_restore --list "$OUT_FILE" | grep -cE 'TABLE|INDEX|EXTENSION' || true)"
 else
   OBJECTS="$(docker run --rm -i "$PG_IMAGE" pg_restore --list < "$OUT_FILE" \
@@ -82,6 +143,7 @@ fi
 
 if [ "${OBJECTS:-0}" -lt 1 ]; then
   echo "ERROR: dump contains no recognisable objects — treat it as FAILED." >&2
+  cleanup_partial
   exit 1
 fi
 


### PR DESCRIPTION
## What broke

The nightly off-Neon dump has failed every night since 2026-08-17:

```
pg_dump: error: aborting because of server version mismatch
pg_dump: detail: server version: 17.11 (df1f1a3); pg_dump version: 16.15 (Ubuntu 16.15-1.pgdg24.04+2)
```

Neon upgraded to 17.11; the GitHub runner ships pg_dump 16.15. The last usable
backup is from **2026-08-16**. With Neon's point-in-time window at 1 day, that
left anything noticed more than 24 hours late unrecoverable.

## Why the existing fallback didn't save us

`backup-db.sh` already had a Docker fallback for exactly this, and both the
script and `db-recovery.yml` carried comments saying so. It could never fire:

```bash
if command -v pg_dump >/dev/null 2>&1; then   # runner has one -> always wins
  pg_dump ...
elif command -v docker >/dev/null 2>&1; then  # unreachable on a runner
```

It was reached only when *no* local `pg_dump` existed at all. A runner has one,
so the too-old client took the branch every time while the container that would
have worked sat unused.

## Changes

- **The local client is a preference, not a commitment.** If it fails and Docker
  is available, the dump is retried in the container.
- **`PG_IMAGE` -> `pgvector/pgvector:pg17`**, which carries pg_dump 17.11 and can
  therefore read Neon.
- **Verification uses the same client that wrote the dump.** `pg_restore 16`
  cannot list a custom-format archive written by `pg_dump 17`, so fixing only the
  dump would have moved the failure to the verify step — one broken step into two.
- **A failure no client can fix now names the server's major version** and says
  which knob to turn, instead of leaving a bare exit code in a run nobody watched.

## Verification

Tested against the local pgvector database on all four paths — healthy local
client, stale local client falling back to the container, stale client with no
Docker, and the container itself failing. The partial dump is removed in every
failing case.

Then run for real against production via `workflow_dispatch`:
[run 32461199411](https://github.com/RithyBondeth/ApsaraTalent-Api/actions/runs/32461199411) — green in 48s.

```
Local pg_dump failed; retrying inside pgvector/pgvector:pg17. It said:
Dumped using pg_dump inside pgvector/pgvector:pg17.
Backup complete: ./backups/apsara-20260821T080126Z.dump (88K, 102 objects)
Uploading 0.1 MB -> ***/database/2026-08-21/apsara-20260821T080126Z.dump
Uploaded. Immutable for the bucket's retention period (30 days).
```

The gap is already closed for today. This PR is what keeps the **scheduled**
run green, since the nightly runs from `main`.

## Notes

- No migrations. `migrate` will be a no-op and `deploy` re-ships the code already
  running.
- Follow-up worth considering: `check-infra-drift.mjs` already reads Neon's
  retention window daily. Asserting `PG_IMAGE`'s major against Neon's reported
  server version would have caught this on 2026-08-17 rather than four nights later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)