### PR TITLE
build(deps): batch the safe dependency work, and drop webpack-cli

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
           # `security-extended` over the default set. Dial back to `security`
@@ -51,6 +51,6 @@ jobs:
           queries: security-extended
 
       - name: Analyze
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -246,7 +246,7 @@ jobs:
 
       - name: Upload scan results
         if: always()
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: trivy-${{ matrix.service }}.sarif
           category: container-${{ matrix.service }}
@@ -390,7 +390,7 @@ jobs:
 
       - name: Upload scan results
         if: always()
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: trivy-monitoring-${{ matrix.service }}.sarif
           category: monitoring-${{ matrix.service }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "@types/passport-google-oauth20": "^2.0.16",
         "@types/passport-linkedin-oauth2": "^1.5.6",
         "@types/pdf-parse": "^1.1.5",
-        "@types/supertest": "^6.0.0",
+        "@types/supertest": "^7.2.1",
         "@typescript-eslint/eslint-plugin": "^8.66.0",
         "@typescript-eslint/parser": "^8.66.0",
         "cross-env": "^10.1.0",
@@ -108,8 +108,7 @@
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
         "typescript": "5.9.3",
-        "webpack": "^5.109.2",
-        "webpack-cli": "^6.0.1"
+        "webpack": "^5.109.2"
       },
       "optionalDependencies": {
         "@img/sharp-linuxmusl-x64": "0.35.3"
@@ -1160,14 +1159,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@discoveryjs/json-ext": {
-      "version": "0.6.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.17.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -5269,7 +5260,9 @@
       }
     },
     "node_modules/@types/supertest": {
-      "version": "6.0.3",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.1.tgz",
+      "integrity": "sha512-4CbBvoYVLHL7+yhbYrZET0vsvuyXTC05aRe7dNQkwMzm56auceoy6Yu3K50uZmwfHna1os3CMSgM/3QVkUtPTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5684,47 +5677,6 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webpack-cli/configtest": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/info": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/serve": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      },
-      "peerDependenciesMeta": {
-        "webpack-dev-server": {
-          "optional": true
-        }
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -6790,19 +6742,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/clone-deep": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "license": "Apache-2.0",
@@ -7392,17 +7331,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/envinfo": {
-      "version": "7.21.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "envinfo": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/error-ex": {
@@ -8093,14 +8021,6 @@
         "fxparser": "src/cli/cli.js"
       }
     },
-    "node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.9.1"
-      }
-    },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
@@ -8261,14 +8181,6 @@
       "optionalDependencies": {
         "@google-cloud/firestore": "^8.6.0",
         "@google-cloud/storage": "^7.19.0"
-      }
-    },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "bin": {
-        "flat": "cli.js"
       }
     },
     "node_modules/flat-cache": {
@@ -9223,14 +9135,6 @@
       "version": "2.0.4",
       "license": "ISC"
     },
-    "node_modules/interpret": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/ioredis": {
       "version": "5.9.3",
       "license": "MIT",
@@ -9341,17 +9245,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "license": "MIT"
@@ -9407,14 +9300,6 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "license": "ISC"
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -10333,14 +10218,6 @@
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
-      }
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/kleur": {
@@ -12155,17 +12032,6 @@
         "node": ">= 12.13.0"
       }
     },
-    "node_modules/rechoir": {
-      "version": "0.8.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve": "^1.20.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
     "node_modules/redis": {
       "version": "5.10.0",
       "license": "MIT",
@@ -12650,17 +12516,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/shallow-clone": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/sharp": {
@@ -14176,68 +14031,6 @@
         }
       }
     },
-    "node_modules/webpack-cli": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@discoveryjs/json-ext": "^0.6.1",
-        "@webpack-cli/configtest": "^3.0.1",
-        "@webpack-cli/info": "^3.0.1",
-        "@webpack-cli/serve": "^3.0.1",
-        "colorette": "^2.0.14",
-        "commander": "^12.1.0",
-        "cross-spawn": "^7.0.3",
-        "envinfo": "^7.14.0",
-        "fastest-levenshtein": "^1.0.12",
-        "import-local": "^3.0.2",
-        "interpret": "^3.1.1",
-        "rechoir": "^0.8.0",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "webpack-cli": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0"
-      },
-      "peerDependenciesMeta": {
-        "webpack-bundle-analyzer": {
-          "optional": true
-        },
-        "webpack-dev-server": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-cli/node_modules/commander": {
-      "version": "12.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/webpack-node-externals": {
       "version": "3.0.0",
       "dev": true,
@@ -14366,11 +14159,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/wildcard": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "@types/passport-google-oauth20": "^2.0.16",
     "@types/passport-linkedin-oauth2": "^1.5.6",
     "@types/pdf-parse": "^1.1.5",
-    "@types/supertest": "^6.0.0",
+    "@types/supertest": "^7.2.1",
     "@typescript-eslint/eslint-plugin": "^8.66.0",
     "@typescript-eslint/parser": "^8.66.0",
     "cross-env": "^10.1.0",
@@ -163,8 +163,7 @@
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "typescript": "5.9.3",
-    "webpack": "^5.109.2",
-    "webpack-cli": "^6.0.1"
+    "webpack": "^5.109.2"
   },
   "optionalDependencies": {
     "@img/sharp-linuxmusl-x64": "0.35.3"


### PR DESCRIPTION
Supersedes #120, #121 and #117. Three changes that would otherwise have been
three separate merges — and every merge to `main` is a full production release,
so a dev-only type bump would have cost a release, a gate approval and seven
redeploys on its own.

| Change | From dependabot | Why |
| --- | --- | --- |
| `@types/supertest` `^6.0.0` -> `^7.2.1` | #120 | aligns the major with supertest 7.2.2 |
| `codeql-action` v4.37.6 -> v4.37.7 | #121 | SHA-pinned, all four call sites |
| `webpack-cli` **removed** | #117 declined | never invoked |

## Why webpack-cli is removed rather than bumped

It appeared exactly once in this repository — its own line in `package.json`.
Nothing invoked it. Nest drives webpack programmatically through
`"webpack": true` in `nest-cli.json`, and `@nestjs/cli` carries its own webpack:

```
deps: {'webpack': '5.106.2', 'webpack-node-externals': '3.0.0', ...}
peer: {}
```

No `webpack-cli` dependency, no peer dependency. The only references anywhere
under `@nestjs/cli` are inside webpack's own `bin/webpack.js`, which mentions
webpack-cli in the hint it prints if you try to run `webpack` directly.

Dropping it removed **18 packages** from the tree. `webpack` itself stays — that
one is genuinely used.

`@types/supertest` was checked the same way and is the opposite case: supertest
7.2.2 ships no types of its own, so the package is real and the major bump is
correct.

## Verification

All seven services build, typecheck and lint clean, 1315 tests pass. The build
is what proves webpack-cli was dead weight rather than a load-bearing dependency
nobody had noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)