### PR TITLE
feat(auth): verify email with a 6-digit code instead of a magic link

### DIFF
--- a/apps/api-gateway/src/auth/basic/controllers/auth.controller.ts
+++ b/apps/api-gateway/src/auth/basic/controllers/auth.controller.ts
@@ -43,10 +43,12 @@ import {
   ResetPasswordResponseDTO,
   RefreshTokenResponseDTO,
   VerifyEmailResponseDTO,
+  ResendEmailOtpResponseDTO,
   CompanyRegisterResponseDTO,
   EmployeeRegisterResponseDTO,
   VerifyOtpResponseDTO,
   VerifyEmailDTO,
+  ResendEmailOtpDTO,
   TwoFactorSetupResponseDTO,
   TwoFactorEnableDTO,
   TwoFactorEnableResponseDTO,
@@ -283,17 +285,34 @@ export class AuthController implements IBasicAuthController {
     return { message: 'Logged out successfully' };
   }
 
-  @Post('verify-email/:emailVerificationToken')
+  // The code arrives in the body, not the path: a six-digit value in a URL
+  // lands in access logs, proxy caches and browser history, and this one is a
+  // credential for the ten minutes it lives.
+  @Post('verify-email')
   @HttpCode(HttpStatus.OK)
   @UseGuards(ThrottlerGuard)
   @StrictThrottle()
   async verifyEmail(
-    @Param('emailVerificationToken') emailVerificationToken: VerifyEmailDTO,
+    @Body() verifyEmailDTO: VerifyEmailDTO,
   ): Promise<VerifyEmailResponseDTO> {
     return await sendAuthServiceRequest<VerifyEmailResponseDTO>(
       this.authClient,
       AUTH_SERVICE.ACTIONS.VERIFY_EMAIL,
-      emailVerificationToken,
+      verifyEmailDTO,
+    );
+  }
+
+  @Post('verify-email/resend')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(ThrottlerGuard)
+  @StrictThrottle()
+  async resendEmailOtp(
+    @Body() resendEmailOtpDTO: ResendEmailOtpDTO,
+  ): Promise<ResendEmailOtpResponseDTO> {
+    return await sendAuthServiceRequest<ResendEmailOtpResponseDTO>(
+      this.authClient,
+      AUTH_SERVICE.ACTIONS.RESEND_EMAIL_OTP,
+      resendEmailOtpDTO,
     );
   }
 

--- a/apps/auth-service/src/basic/controllers/verify-email.controller.ts
+++ b/apps/auth-service/src/basic/controllers/verify-email.controller.ts
@@ -6,7 +6,12 @@ import {
   I_VERIFY_EMAIL_SERVICE,
   IVerifyEmailService,
 } from '@app/contracts/interfaces/service/auth-service.interface';
-import { VerifyEmailDTO, VerifyEmailResponseDTO } from '@app/contracts';
+import {
+  ResendEmailOtpDTO,
+  ResendEmailOtpResponseDTO,
+  VerifyEmailDTO,
+  VerifyEmailResponseDTO,
+} from '@app/contracts';
 
 @Controller()
 export class VerifyEmailController implements IBasicAuthVerifyEmailRpcController {
@@ -20,5 +25,12 @@ export class VerifyEmailController implements IBasicAuthVerifyEmailRpcController
     @Payload() verifyEmailDTO: VerifyEmailDTO,
   ): Promise<VerifyEmailResponseDTO> {
     return this.verifyEmailService.verifyEmail(verifyEmailDTO);
+  }
+
+  @MessagePattern(AUTH_SERVICE.ACTIONS.RESEND_EMAIL_OTP)
+  async resendEmailOtp(
+    @Payload() resendEmailOtpDTO: ResendEmailOtpDTO,
+  ): Promise<ResendEmailOtpResponseDTO> {
+    return this.verifyEmailService.resendEmailOtp(resendEmailOtpDTO);
   }
 }

--- a/apps/auth-service/src/basic/services/register.service.spec.ts
+++ b/apps/auth-service/src/basic/services/register.service.spec.ts
@@ -12,7 +12,6 @@ describe('RegisterService', () => {
   const users = { exists: jest.fn() };
   const config = { get: jest.fn(() => 'https://app.example.com') };
   const jwt = {
-    generateEmailVerificationToken: jest.fn(),
     generateToken: jest.fn(),
     generateRefreshToken: jest.fn(),
   };
@@ -49,7 +48,6 @@ describe('RegisterService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     users.exists.mockResolvedValue(false);
-    jwt.generateEmailVerificationToken.mockResolvedValue('verify-token');
     jwt.generateToken.mockResolvedValue('access');
     jwt.generateRefreshToken.mockResolvedValue('refresh');
     email.sendEmail.mockResolvedValue({ messageId: 'email-1' });
@@ -99,8 +97,12 @@ describe('RegisterService', () => {
       info: 'employee@example.com',
       role: 'employee',
     });
+    // The verification mail must carry a six-digit code, not a link.
     expect(email.sendEmail).toHaveBeenCalledWith(
-      expect.objectContaining({ to: 'employee@example.com' }),
+      expect.objectContaining({
+        to: 'employee@example.com',
+        text: expect.stringMatching(/\b\d{6}\b/),
+      }),
     );
     expect(result).toEqual(
       expect.objectContaining({
@@ -220,7 +222,10 @@ describe('RegisterService', () => {
       expect.objectContaining({ title: 'Developer' }),
     );
     expect(email.sendEmail).toHaveBeenCalledWith(
-      expect.objectContaining({ to: 'company@example.com' }),
+      expect.objectContaining({
+        to: 'company@example.com',
+        text: expect.stringMatching(/\b\d{6}\b/),
+      }),
     );
     expect(result.message).toContain('verify your email');
   });

--- a/apps/auth-service/src/basic/services/register.service.ts
+++ b/apps/auth-service/src/basic/services/register.service.ts
@@ -14,6 +14,8 @@ import { JwtService } from '@app/common/jwt/jwt.service';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { RpcException } from '@nestjs/microservices';
+import { AUTH } from '@app/contracts/constants/domain/auth.constant';
+import { buildOtpEmail, VerifyEmailService } from './verify-email.service';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   CompanyResponseDTO,
@@ -64,13 +66,11 @@ export class RegisterService implements IRegisterService {
         statusCode: 401,
       });
 
-    // Generate email verification token in parallel with nothing blocking
-    const emailVerificationToken =
-      await this.jwtService.generateEmailVerificationToken(
-        companyRegisterDTO.authEmail
-          ? companyRegisterDTO.email
-          : companyRegisterDTO.phone,
-      );
+    // A six-digit code, not a signed link — see VerifyEmailService for why.
+    const emailVerificationOtp = VerifyEmailService.generateOtp();
+    const emailVerificationOtpExpires = new Date(
+      Date.now() + AUTH.EMAIL_OTP_EXPIRY,
+    );
 
     // ── Transaction: all DB writes are atomic ──────────────────────
     const queryRunner = this.dataSource.createQueryRunner();
@@ -175,8 +175,11 @@ export class RegisterService implements IRegisterService {
         password: companyRegisterDTO.password,
         company: newCompany,
         isEmailVerified: false,
-        emailVerificationToken: companyRegisterDTO.authEmail
-          ? emailVerificationToken
+        emailVerificationOtp: companyRegisterDTO.authEmail
+          ? emailVerificationOtp
+          : null,
+        emailVerificationOtpExpires: companyRegisterDTO.authEmail
+          ? emailVerificationOtpExpires
           : null,
         profileCompleted: true,
       });
@@ -214,9 +217,8 @@ export class RegisterService implements IRegisterService {
       this.emailService
         .sendEmail({
           to: company.email,
-          subject: 'Apsara Talent - Verify Your Email Address',
-          text: `Hello, ${company.company.name}. Please verify your email address by clicking on the following link:
-          ${this.configService.get<string>('CLIENT_URL')}/login/email-verification/${emailVerificationToken}`,
+          subject: 'Apsara Talent - Your verification code',
+          text: buildOtpEmail(emailVerificationOtp),
         })
         .catch((err) =>
           this.logger.error(
@@ -265,13 +267,11 @@ export class RegisterService implements IRegisterService {
         statusCode: 401,
       });
 
-    // Generate email verification token
-    const emailVerificationToken =
-      await this.jwtService.generateEmailVerificationToken(
-        employeeRegisterDTO.authEmail
-          ? employeeRegisterDTO.email
-          : employeeRegisterDTO.phone,
-      );
+    // A six-digit code, not a signed link — see VerifyEmailService for why.
+    const emailVerificationOtp = VerifyEmailService.generateOtp();
+    const emailVerificationOtpExpires = new Date(
+      Date.now() + AUTH.EMAIL_OTP_EXPIRY,
+    );
 
     // ── Transaction: all DB writes are atomic ──────────────────────
     const queryRunner = this.dataSource.createQueryRunner();
@@ -373,8 +373,11 @@ export class RegisterService implements IRegisterService {
         password: employeeRegisterDTO.password,
         employee: newEmployee,
         isEmailVerified: employeeRegisterDTO.authEmail ? false : true,
-        emailVerificationToken: employeeRegisterDTO.authEmail
-          ? emailVerificationToken
+        emailVerificationOtp: employeeRegisterDTO.authEmail
+          ? emailVerificationOtp
+          : null,
+        emailVerificationOtpExpires: employeeRegisterDTO.authEmail
+          ? emailVerificationOtpExpires
           : null,
         profileCompleted: true,
       });
@@ -412,9 +415,8 @@ export class RegisterService implements IRegisterService {
       this.emailService
         .sendEmail({
           to: employee.email,
-          subject: 'Apsara Talent - Verify Your Email Address',
-          text: `Hello, ${employee.employee.username}. Please verify your email address by clicking on the following link:
-          ${this.configService.get<string>('CLIENT_URL')}/login/email-verification/${emailVerificationToken}`,
+          subject: 'Apsara Talent - Your verification code',
+          text: buildOtpEmail(emailVerificationOtp),
         })
         .catch((err) =>
           this.logger.error(

--- a/apps/auth-service/src/basic/services/verify-email.service.spec.ts
+++ b/apps/auth-service/src/basic/services/verify-email.service.spec.ts
@@ -1,52 +1,152 @@
 import { RpcException } from '@nestjs/microservices';
+import { AUTH } from '@app/contracts/constants/domain/auth.constant';
 import { VerifyEmailService } from './verify-email.service';
 
 describe('VerifyEmailService', () => {
   const repository = { findOne: jest.fn(), save: jest.fn() };
-  const jwt = { verifyEmailToken: jest.fn() };
-  const logger = { error: jest.fn() };
+  const email = { sendEmail: jest.fn() };
+  const logger = { error: jest.fn(), debug: jest.fn() };
   const service = new VerifyEmailService(
     repository as any,
-    jwt as any,
+    email as any,
     logger as any,
   );
 
+  const pendingUser = (over: Record<string, unknown> = {}) => ({
+    email: 'person@example.com',
+    isEmailVerified: false,
+    emailVerificationOtp: '123456',
+    emailVerificationOtpExpires: new Date(Date.now() + 60_000),
+    emailVerificationAttempts: 0,
+    ...over,
+  });
+
   beforeEach(() => jest.clearAllMocks());
 
-  it('binds the signed email and stored token before verifying an account', async () => {
-    const user = { isEmailVerified: false, emailVerificationToken: 'token' };
-    jwt.verifyEmailToken.mockResolvedValue({ email: 'person@example.com' });
-    repository.findOne.mockResolvedValue(user);
+  describe('verifyEmail', () => {
+    it('verifies the account and clears the code on a correct guess', async () => {
+      const user = pendingUser();
+      repository.findOne.mockResolvedValue(user);
 
-    await service.verifyEmail({ emailVerificationToken: 'token' });
+      await service.verifyEmail({ email: user.email, otp: '123456' });
 
-    expect(repository.findOne).toHaveBeenCalledWith({
-      where: { emailVerificationToken: 'token', email: 'person@example.com' },
+      expect(repository.findOne).toHaveBeenCalledWith({
+        where: { email: 'person@example.com' },
+      });
+      expect(user.isEmailVerified).toBe(true);
+      expect(user.emailVerificationOtp).toBeNull();
+      expect(user.emailVerificationOtpExpires).toBeNull();
+      expect(user.emailVerificationAttempts).toBe(0);
     });
-    expect(user).toEqual({
-      isEmailVerified: true,
-      emailVerificationToken: null,
+
+    it('counts a wrong guess without burning the code', async () => {
+      const user = pendingUser();
+      repository.findOne.mockResolvedValue(user);
+
+      await expect(
+        service.verifyEmail({ email: user.email, otp: '000000' }),
+      ).rejects.toBeInstanceOf(RpcException);
+
+      expect(user.emailVerificationAttempts).toBe(1);
+      expect(user.emailVerificationOtp).toBe('123456');
+      expect(user.isEmailVerified).toBe(false);
     });
-    expect(repository.save).toHaveBeenCalledWith(user);
-  });
 
-  it('rejects a token that does not map to an account', async () => {
-    jwt.verifyEmailToken.mockResolvedValue({ email: 'person@example.com' });
-    repository.findOne.mockResolvedValue(null);
-    await expect(
-      service.verifyEmail({ emailVerificationToken: 'token' }),
-    ).rejects.toBeInstanceOf(RpcException);
-  });
+    it('burns the code once the attempt budget is spent', async () => {
+      const user = pendingUser({
+        emailVerificationAttempts: AUTH.EMAIL_OTP_MAX_ATTEMPTS - 1,
+      });
+      repository.findOne.mockResolvedValue(user);
 
-  it('maps token verification failures to an RPC server error', async () => {
-    jwt.verifyEmailToken.mockRejectedValue(new Error('invalid signature'));
-    await service
-      .verifyEmail({ emailVerificationToken: 'token' })
-      .catch((error: RpcException) =>
-        expect(error.getError()).toEqual({
-          message: 'invalid signature',
-          statusCode: 500,
-        }),
+      await expect(
+        service.verifyEmail({ email: user.email, otp: '000000' }),
+      ).rejects.toBeInstanceOf(RpcException);
+
+      // Burned, not merely counted — otherwise the throttle is the only limit.
+      expect(user.emailVerificationOtp).toBeNull();
+      expect(user.isEmailVerified).toBe(false);
+    });
+
+    it('rejects and clears an expired code', async () => {
+      const user = pendingUser({
+        emailVerificationOtpExpires: new Date(Date.now() - 1),
+      });
+      repository.findOne.mockResolvedValue(user);
+
+      await expect(
+        service.verifyEmail({ email: user.email, otp: '123456' }),
+      ).rejects.toBeInstanceOf(RpcException);
+
+      expect(user.emailVerificationOtp).toBeNull();
+      expect(user.isEmailVerified).toBe(false);
+    });
+
+    it.each([
+      ['no account', null],
+      ['an already-verified account', { isEmailVerified: true }],
+      ['no outstanding code', { emailVerificationOtp: null }],
+    ])('gives nothing away when there is %s', async (_label, over) => {
+      repository.findOne.mockResolvedValue(
+        over === null ? null : pendingUser(over as Record<string, unknown>),
       );
+
+      await service
+        .verifyEmail({ email: 'person@example.com', otp: '123456' })
+        .catch((error: RpcException) =>
+          expect(error.getError()).toEqual({
+            message: 'Invalid or expired verification code',
+            statusCode: 401,
+          }),
+        );
+    });
+  });
+
+  describe('resendEmailOtp', () => {
+    it('issues a fresh code, resets the attempts and mails it', async () => {
+      const user = pendingUser({
+        emailVerificationOtp: 'stale',
+        emailVerificationAttempts: 3,
+      });
+      repository.findOne.mockResolvedValue(user);
+
+      await service.resendEmailOtp({ email: user.email });
+
+      expect(user.emailVerificationOtp).toMatch(/^\d{6}$/);
+      expect(user.emailVerificationOtp).not.toBe('stale');
+      expect(user.emailVerificationAttempts).toBe(0);
+      expect(email.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'person@example.com' }),
+      );
+      // The code must reach the inbox, never the API response.
+      expect(
+        JSON.stringify(await service.resendEmailOtp({ email: user.email })),
+      ).not.toContain(user.emailVerificationOtp);
+    });
+
+    it('answers the same for an unknown address and sends nothing', async () => {
+      repository.findOne.mockResolvedValue(null);
+
+      const response = await service.resendEmailOtp({
+        email: 'stranger@example.com',
+      });
+
+      expect(response.message).toContain('stranger@example.com');
+      expect(email.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('does not re-mail an already-verified account', async () => {
+      repository.findOne.mockResolvedValue(
+        pendingUser({ isEmailVerified: true }),
+      );
+
+      await service.resendEmailOtp({ email: 'person@example.com' });
+
+      expect(email.sendEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  it('generates six digits with no leading-zero truncation', () => {
+    for (let i = 0; i < 200; i++)
+      expect(VerifyEmailService.generateOtp()).toMatch(/^\d{6}$/);
   });
 });

--- a/apps/auth-service/src/basic/services/verify-email.service.ts
+++ b/apps/auth-service/src/basic/services/verify-email.service.ts
@@ -1,47 +1,94 @@
 import { User } from '@app/common/database/entities/user.entity';
-import { JwtService } from '@app/common/jwt/jwt.service';
+import { EmailService } from '@app/common/email/email.service';
 import { Injectable } from '@nestjs/common';
 import { RpcException } from '@nestjs/microservices';
 import { InjectRepository } from '@nestjs/typeorm';
 import { PinoLogger } from 'nestjs-pino';
 import { Repository } from 'typeorm';
-import { VerifyEmailDTO, VerifyEmailResponseDTO } from '@app/contracts';
+import {
+  ResendEmailOtpDTO,
+  ResendEmailOtpResponseDTO,
+  VerifyEmailDTO,
+  VerifyEmailResponseDTO,
+} from '@app/contracts';
+import { AUTH } from '@app/contracts/constants/domain/auth.constant';
 import { IVerifyEmailService } from '@app/contracts/interfaces/service/auth-service.interface';
 
+/**
+ * Email verification by 6-digit code.
+ *
+ * This replaced a magic link carrying a signed JWT. The link only worked on the
+ * device that opened the mail, which is the wrong device whenever someone signs
+ * up on a laptop and reads mail on a phone. A code can be carried between them.
+ *
+ * The trade is that a link is unguessable and six digits are one of a million,
+ * so the code is defended on three sides: it expires (10 minutes), it burns
+ * after a fixed number of wrong guesses, and the route it arrives on is
+ * strict-throttled per IP. Losing any one of those makes this weaker than what
+ * it replaced.
+ */
 @Injectable()
 export class VerifyEmailService implements IVerifyEmailService {
   constructor(
     @InjectRepository(User) private readonly userRepository: Repository<User>,
-    private readonly jwtService: JwtService,
+    private readonly emailService: EmailService,
     private readonly logger: PinoLogger,
   ) {}
+
+  /** Six digits, never leading-zero-stripped. */
+  static generateOtp(): string {
+    return Math.floor(AUTH.OTP_MIN + Math.random() * AUTH.OTP_RANGE).toString();
+  }
 
   async verifyEmail(
     verifyEmailDTO: VerifyEmailDTO,
   ): Promise<VerifyEmailResponseDTO> {
     try {
-      //Find the user by email verification token
-      const decoded = await this.jwtService.verifyEmailToken(
-        verifyEmailDTO.emailVerificationToken,
-      );
       const user = await this.userRepository.findOne({
-        where: {
-          emailVerificationToken: verifyEmailDTO.emailVerificationToken,
-          email: decoded.email,
-        },
+        where: { email: verifyEmailDTO.email },
       });
-      if (!user)
+
+      // One message for "no such account", "already verified" and "no code
+      // outstanding". Distinguishing them would turn this route into an
+      // account-existence oracle for anyone who can send requests.
+      if (!user || user.isEmailVerified || !user.emailVerificationOtp)
         throw new RpcException({
-          message: 'Invalid Credential',
+          message: 'Invalid or expired verification code',
           statusCode: 401,
         });
 
-      //Set email verification to true and email verification token to null
-      user.isEmailVerified = true;
-      user.emailVerificationToken = null;
+      if (
+        !user.emailVerificationOtpExpires ||
+        user.emailVerificationOtpExpires < new Date()
+      ) {
+        await this.clearOtp(user);
+        throw new RpcException({
+          message: 'Verification code has expired. Request a new one.',
+          statusCode: 401,
+        });
+      }
 
-      //Save user into the database
-      await this.userRepository.save(user);
+      if (user.emailVerificationOtp !== verifyEmailDTO.otp) {
+        user.emailVerificationAttempts += 1;
+
+        // Burn the code rather than leaving it live for the next guess.
+        if (user.emailVerificationAttempts >= AUTH.EMAIL_OTP_MAX_ATTEMPTS) {
+          await this.clearOtp(user);
+          throw new RpcException({
+            message: 'Too many incorrect attempts. Request a new code.',
+            statusCode: 401,
+          });
+        }
+
+        await this.userRepository.save(user);
+        throw new RpcException({
+          message: 'Invalid or expired verification code',
+          statusCode: 401,
+        });
+      }
+
+      user.isEmailVerified = true;
+      await this.clearOtp(user);
 
       return new VerifyEmailResponseDTO({
         message: 'Your email was verified successfully. Now you can login',
@@ -57,4 +104,72 @@ export class VerifyEmailService implements IVerifyEmailService {
       });
     }
   }
+
+  async resendEmailOtp(
+    resendEmailOtpDTO: ResendEmailOtpDTO,
+  ): Promise<ResendEmailOtpResponseDTO> {
+    try {
+      const user = await this.userRepository.findOne({
+        where: { email: resendEmailOtpDTO.email },
+      });
+
+      // Always the same answer, whether or not the address exists. The caller
+      // learns nothing about who is registered; the mail only lands for real,
+      // unverified accounts.
+      const acknowledgement = new ResendEmailOtpResponseDTO({
+        message: `If that address needs verifying, a new code is on its way to ${resendEmailOtpDTO.email}`,
+      });
+
+      if (!user || user.isEmailVerified) return acknowledgement;
+
+      const otp = VerifyEmailService.generateOtp();
+      user.emailVerificationOtp = otp;
+      user.emailVerificationOtpExpires = new Date(
+        Date.now() + AUTH.EMAIL_OTP_EXPIRY,
+      );
+      user.emailVerificationAttempts = 0;
+      await this.userRepository.save(user);
+
+      await this.emailService.sendEmail({
+        to: user.email,
+        subject: 'Apsara Talent - Your verification code',
+        text: buildOtpEmail(otp),
+      });
+
+      this.logger.debug(
+        { email: user.email },
+        'Email verification code reissued',
+      );
+
+      return acknowledgement;
+    } catch (error) {
+      this.logger.error(
+        (error as Error).message || 'An error occurred while resending code.',
+      );
+      if (error instanceof RpcException) throw error;
+      throw new RpcException({
+        message: (error as Error).message,
+        statusCode: 500,
+      });
+    }
+  }
+
+  private async clearOtp(user: User): Promise<void> {
+    user.emailVerificationOtp = null;
+    user.emailVerificationOtpExpires = null;
+    user.emailVerificationAttempts = 0;
+    await this.userRepository.save(user);
+  }
+}
+
+/** Shared so registration and resend cannot drift into two different emails. */
+export function buildOtpEmail(otp: string): string {
+  const minutes = Math.round(AUTH.EMAIL_OTP_EXPIRY / 60_000);
+  return [
+    'Welcome to Apsara Talent.',
+    '',
+    `Your email verification code is: ${otp}`,
+    '',
+    `The code expires in ${minutes} minutes. If you did not create an account, you can ignore this message.`,
+  ].join('\n');
 }

--- a/libs/common/src/database/entities/user.entity.ts
+++ b/libs/common/src/database/entities/user.entity.ts
@@ -76,8 +76,16 @@ export class User {
   @Column({ default: false })
   isEmailVerified: boolean;
 
+  /** Six-digit email verification code. Null once verified or expired. */
   @Column({ nullable: true })
-  emailVerificationToken: string | null;
+  emailVerificationOtp: string | null;
+
+  @Column({ nullable: true })
+  emailVerificationOtpExpires: Date | null;
+
+  /** Wrong guesses against the current code; the code is burned at the cap. */
+  @Column({ default: 0 })
+  emailVerificationAttempts: number;
 
   @Column({ default: false })
   isTwoFactorEnabled: boolean;

--- a/libs/common/src/jwt/jwt.service.spec.ts
+++ b/libs/common/src/jwt/jwt.service.spec.ts
@@ -60,32 +60,16 @@ describe('JwtService token boundaries', () => {
       { id: 'user-1', type: 'refresh' },
       { expiresIn: '30d' },
     );
-    await configured.generateEmailVerificationToken('person@example.com');
-    expect(nestJwtService.signAsync).toHaveBeenLastCalledWith(
-      { email: 'person@example.com', type: 'email-verification' },
-      { expiresIn: '15m' },
-    );
   });
 
-  it('accepts only correctly typed refresh and email-verification tokens', async () => {
+  it('accepts only correctly typed refresh tokens', async () => {
     nestJwtService.verifyAsync
       .mockResolvedValueOnce({ id: 'user-1', type: 'refresh' })
-      .mockResolvedValueOnce({
-        email: 'person@example.com',
-        type: 'email-verification',
-      })
-      .mockResolvedValueOnce({ type: 'access' })
       .mockResolvedValueOnce({ type: 'access' });
     await expect(service.verifyRefreshToken('refresh')).resolves.toEqual(
       expect.objectContaining({ type: 'refresh' }),
     );
-    await expect(service.verifyEmailToken('email')).resolves.toEqual(
-      expect.objectContaining({ type: 'email-verification' }),
-    );
     await expect(service.verifyRefreshToken('access')).rejects.toThrow(
-      'Invalid token type',
-    );
-    await expect(service.verifyEmailToken('access')).rejects.toThrow(
       'Invalid token type',
     );
   });

--- a/libs/common/src/jwt/jwt.service.ts
+++ b/libs/common/src/jwt/jwt.service.ts
@@ -30,14 +30,6 @@ export class JwtService {
     return refreshToken;
   }
 
-  async generateEmailVerificationToken(email: string): Promise<string> {
-    const token = await this.jwtService.signAsync(
-      { email, type: 'email-verification' },
-      { expiresIn: this.configService.get<StringValue>('jwt.emailExpiresIn') },
-    );
-    return token;
-  }
-
   async verifyToken(token: string): Promise<any> {
     try {
       const decoded = await this.jwtService.verifyAsync(token);
@@ -55,20 +47,6 @@ export class JwtService {
     try {
       const decoded = await this.jwtService.verifyAsync(token);
       if (decoded.type !== 'refresh') throw new Error('Invalid token type');
-      return decoded;
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      this.logger.error(errorMessage);
-      throw new Error(errorMessage);
-    }
-  }
-
-  async verifyEmailToken(token: string): Promise<any> {
-    try {
-      const decoded = await this.jwtService.verifyAsync(token);
-      if (decoded.type !== 'email-verification')
-        throw new Error('Invalid token type');
       return decoded;
     } catch (error) {
       const errorMessage =

--- a/libs/contracts/src/constants/domain/auth.constant.ts
+++ b/libs/contracts/src/constants/domain/auth.constant.ts
@@ -13,6 +13,14 @@ export const AUTH = {
   OTP_MIN: 100_000,
   /** OTP generation range (random * 900000 keeps it 6 digits) */
   OTP_RANGE: 900_000,
+  /** Email verification code validity window — 10 minutes.
+   *  Longer than the login OTP because this code is read from an inbox, which
+   *  can lag, rather than from an SMS that arrives in seconds. */
+  EMAIL_OTP_EXPIRY: 10 * 60 * 1_000,
+  /** Wrong guesses allowed before the code is burned and must be resent.
+   *  A 6-digit code is one of a million; without this the route's IP throttle
+   *  is the only thing standing between an attacker and a verified address. */
+  EMAIL_OTP_MAX_ATTEMPTS: 5,
   /** Maximum time login flows wait for best-effort cache invalidation */
   CACHE_CLEANUP_TIMEOUT: 3_000,
   /** Timeout for OAuth callback RPC — 10 seconds */

--- a/libs/contracts/src/constants/service-actions/auth-service.constant.ts
+++ b/libs/contracts/src/constants/service-actions/auth-service.constant.ts
@@ -10,6 +10,7 @@ export const AUTH_SERVICE = {
     RESET_PASSWORD: { cmd: 'reset-password' },
     REFRESH_TOKEN: { cmd: 'refresh-token' },
     VERIFY_EMAIL: { cmd: 'verify-email' },
+    RESEND_EMAIL_OTP: { cmd: 'resend-email-otp' },
     GOOGLE_AUTH: { cmd: 'google-auth' },
     LINKEDIN_AUTH: { cmd: 'linkedin-auth' },
     GITHUB_AUTH: { cmd: 'github-auth' },

--- a/libs/contracts/src/dtos/auth/verify-email.dto.ts
+++ b/libs/contracts/src/dtos/auth/verify-email.dto.ts
@@ -1,14 +1,39 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsNumberString, Length } from 'class-validator';
 import { ForgotPasswordResponseDTO } from './forgot-password.dto';
 
+/**
+ * Email verification by 6-digit code.
+ *
+ * The code alone is not enough to identify the account: six digits collide
+ * across a large user table, so the email scopes the lookup. It also means an
+ * attacker has to know the address they are attacking rather than sweeping for
+ * any code that happens to be live.
+ */
 export class VerifyEmailDTO {
-  @IsString()
+  @IsEmail()
   @IsNotEmpty()
-  emailVerificationToken: string;
+  email: string;
+
+  @IsNumberString({ no_symbols: true })
+  @Length(6, 6)
+  otp: string;
 }
 
 export class VerifyEmailResponseDTO extends ForgotPasswordResponseDTO {
   constructor(partial: Partial<VerifyEmailResponseDTO>) {
+    super(partial);
+  }
+}
+
+/** Issue a fresh code, invalidating whatever was outstanding. */
+export class ResendEmailOtpDTO {
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+}
+
+export class ResendEmailOtpResponseDTO extends ForgotPasswordResponseDTO {
+  constructor(partial: Partial<ResendEmailOtpResponseDTO>) {
     super(partial);
   }
 }

--- a/libs/contracts/src/dtos/job/jobs/search-job.dto.ts
+++ b/libs/contracts/src/dtos/job/jobs/search-job.dto.ts
@@ -143,7 +143,13 @@ export class UserInJobResponseDTO {
   isEmailVerified: boolean;
   @Exclude()
   @ApiHideProperty()
-  emailVerificationToken: string | null;
+  emailVerificationOtp: string | null;
+  @Exclude()
+  @ApiHideProperty()
+  emailVerificationOtpExpires: Date | null;
+  @Exclude()
+  @ApiHideProperty()
+  emailVerificationAttempts: number;
   @Exclude()
   @ApiHideProperty()
   isTwoFactorEnabled: boolean;

--- a/libs/contracts/src/dtos/shared/user.dto.ts
+++ b/libs/contracts/src/dtos/shared/user.dto.ts
@@ -273,7 +273,13 @@ export class UserResponseDTO {
   profileCompleted?: boolean;
   @Exclude()
   @ApiHideProperty()
-  emailVerificationToken?: string;
+  emailVerificationOtp?: string;
+  @Exclude()
+  @ApiHideProperty()
+  emailVerificationOtpExpires?: Date;
+  @Exclude()
+  @ApiHideProperty()
+  emailVerificationAttempts?: number;
   isTwoFactorEnabled?: boolean;
   @Exclude()
   @ApiHideProperty()

--- a/libs/contracts/src/interfaces/controller/auth-controller.interface.ts
+++ b/libs/contracts/src/interfaces/controller/auth-controller.interface.ts
@@ -4,6 +4,7 @@ import {
   ResetPasswordResponseDTO,
   RefreshTokenResponseDTO,
   VerifyEmailResponseDTO,
+  ResendEmailOtpResponseDTO,
   CompanyRegisterResponseDTO,
   EmployeeRegisterResponseDTO,
   LoginDTO,
@@ -17,6 +18,7 @@ import {
   LoginOtpDTO,
   LoginOtpResponseDTO,
   VerifyEmailDTO,
+  ResendEmailOtpDTO,
   TwoFactorSetupResponseDTO,
   TwoFactorEnableDTO,
   TwoFactorEnableResponseDTO,
@@ -78,15 +80,17 @@ export interface IBasicAuthRefreshTokenRpcController {
 }
 
 export interface IBasicAuthVerifyEmailController {
-  verifyEmail(
-    emailVerificationToken: VerifyEmailDTO,
-  ): Promise<VerifyEmailResponseDTO>;
+  verifyEmail(verifyEmailDTO: VerifyEmailDTO): Promise<VerifyEmailResponseDTO>;
+  resendEmailOtp(
+    resendEmailOtpDTO: ResendEmailOtpDTO,
+  ): Promise<ResendEmailOtpResponseDTO>;
 }
 
 export interface IBasicAuthVerifyEmailRpcController {
-  verifyEmail(
-    emailVerificationToken: VerifyEmailDTO,
-  ): Promise<VerifyEmailResponseDTO>;
+  verifyEmail(verifyEmailDTO: VerifyEmailDTO): Promise<VerifyEmailResponseDTO>;
+  resendEmailOtp(
+    resendEmailOtpDTO: ResendEmailOtpDTO,
+  ): Promise<ResendEmailOtpResponseDTO>;
 }
 
 export interface IBasicAuthRegisterController {

--- a/libs/contracts/src/interfaces/service/auth-service.interface.ts
+++ b/libs/contracts/src/interfaces/service/auth-service.interface.ts
@@ -18,6 +18,7 @@ import {
   RefreshTokenResponseDTO,
   RefreshTokenDTO,
   VerifyEmailResponseDTO,
+  ResendEmailOtpResponseDTO,
   VerifyOtpDTO,
   VerifyOtpResponseDTO,
   FacebookLoginResponseDTO,
@@ -25,6 +26,7 @@ import {
   GoogleLoginResponseDTO,
   LinkedInLoginResponseDTO,
   VerifyEmailDTO,
+  ResendEmailOtpDTO,
   TwoFactorSetupDTO,
   TwoFactorSetupResponseDTO,
   TwoFactorEnableDTO,
@@ -83,6 +85,9 @@ export interface IRefreshTokenService {
 
 export interface IVerifyEmailService {
   verifyEmail(verifyEmailDTO: VerifyEmailDTO): Promise<VerifyEmailResponseDTO>;
+  resendEmailOtp(
+    resendEmailOtpDTO: ResendEmailOtpDTO,
+  ): Promise<ResendEmailOtpResponseDTO>;
 }
 
 export interface ILoginOTPService {

--- a/migrations/1786500004000-EmailVerificationOtp.ts
+++ b/migrations/1786500004000-EmailVerificationOtp.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Move email verification from a magic-link JWT to a 6-digit code.
+ *
+ * `emailVerificationToken` held a signed JWT that arrived as a link. The code
+ * that replaces it is six digits, so three things change shape:
+ *
+ *  - it expires on its own (`...OtpExpires`) rather than relying on the JWT's
+ *    internal exp, because nothing signs it any more;
+ *  - it needs an attempt counter. A JWT is not guessable; a 6-digit code is one
+ *    of a million, so without a per-code budget the move to OTP would be a
+ *    downgrade in security rather than a change in delivery. The service burns
+ *    the code once the counter is exhausted.
+ *
+ * Existing unverified accounts lose their pending token and simply request a
+ * new code — the old links stop working the moment this deploys, which is the
+ * point of removing them. Verified accounts are untouched: `isEmailVerified`
+ * is not part of this migration.
+ */
+export class EmailVerificationOtp1786500004000 implements MigrationInterface {
+  name = 'EmailVerificationOtp1786500004000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "user"
+        ADD COLUMN IF NOT EXISTS "emailVerificationOtp" character varying,
+        ADD COLUMN IF NOT EXISTS "emailVerificationOtpExpires" TIMESTAMP,
+        ADD COLUMN IF NOT EXISTS "emailVerificationAttempts" integer NOT NULL DEFAULT 0;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "user" DROP COLUMN IF EXISTS "emailVerificationToken";
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "user"
+        ADD COLUMN IF NOT EXISTS "emailVerificationToken" character varying;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "user"
+        DROP COLUMN IF EXISTS "emailVerificationOtp",
+        DROP COLUMN IF EXISTS "emailVerificationOtpExpires",
+        DROP COLUMN IF EXISTS "emailVerificationAttempts";
+    `);
+  }
+}

--- a/migrations/migrations.spec.ts
+++ b/migrations/migrations.spec.ts
@@ -15,6 +15,7 @@ import { FlexibleCompanyTypeAndJobLanguages1786500000000 } from './1786500000000
 import { NormalizeEmploymentTypes1786500001000 } from './1786500001000-NormalizeEmploymentTypes';
 import { JobSkillsRelation1786500002000 } from './1786500002000-JobSkillsRelation';
 import { AddMatchScore1786500003000 } from './1786500003000-AddMatchScore';
+import { EmailVerificationOtp1786500004000 } from './1786500004000-EmailVerificationOtp';
 
 // Read rather than imported: the tsconfig does not enable resolveJsonModule,
 // and reading it the same way scripts/ci/migration-rehearsal.mjs does keeps
@@ -46,6 +47,7 @@ describe('database migration contracts', () => {
     ],
     ['job skills relation', new JobSkillsRelation1786500002000()],
     ['match score column', new AddMatchScore1786500003000()],
+    ['email verification otp', new EmailVerificationOtp1786500004000()],
   ] as const;
 
   it.each(migrations)(


### PR DESCRIPTION
## What

Email verification moves from a magic link carrying a signed JWT to a 6-digit code.

The link only worked on the device that opened the inbox — the wrong device whenever someone signs up on a laptop and reads mail on a phone.

## Why it needed more than a delivery swap

A link is unguessable; six digits are one of a million. So the code is defended on three sides rather than one:

| | |
|---|---|
| **10-minute expiry** | longer than the phone OTP, because inboxes lag where SMS doesn't |
| **5-attempt budget** | the code is *burned*, not just counted — otherwise the per-IP throttle is the only limit |
| **`StrictThrottle()`** | kept on both routes |

Drop any one and this is weaker than what it replaced.

## Also in here

- **`POST /auth/verify-email/resend`** — codes expire, so without it a slow inbox means an account nobody can finish creating.
- **Credential out of the URL** — the old route took the token as a path segment, where it lands in access logs, proxy caches and browser history. The code now travels in the body.
- **No account-existence oracle** — "no such account", "already verified" and "no code outstanding" all answer identically, and resend acknowledges unknown addresses without sending mail.
- **Dead code removed** — `JwtService.generateEmailVerificationToken` and `verifyEmailToken`, unused once nothing signs a link.

## A latent bug this fixes

The old gateway declared `@Param('emailVerificationToken') emailVerificationToken: VerifyEmailDTO` and forwarded the bare string, while the service read `.emailVerificationToken` off it — `undefined`. **Email verification could not have been working.**

## Migration

`1786500004000-EmailVerificationOtp` drops `emailVerificationToken` and adds `emailVerificationOtp`, `...OtpExpires`, `...Attempts`. Registered in the migration contract spec; forward and rollback SQL both verified.

⚠️ **Not run against any database.** Accounts mid-verification when this deploys will need a fresh code — resend covers them.

## Verification

- ESLint clean
- `tsc --noEmit` clean *apart from the pre-existing `pdf-parse` errors on develop* (confirmed by stashing: they fail on clean develop too)
- **1320 tests pass**, including 11 new verification tests and 34 migration contracts
- The one failing suite, `resume-parse.service.spec.ts`, fails identically on clean develop

Pairs with ApsaraTalent-Web#feat/email-verification-otp — **merge the API first**, or the web page will call endpoints that don't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)