### PR TITLE
fix(user): expose isTwoFactorEnabled so 2FA can be turned back off

### DIFF
--- a/apps/user-service/src/users/services/user.service.spec.ts
+++ b/apps/user-service/src/users/services/user.service.spec.ts
@@ -146,6 +146,7 @@ describe('UserService', () => {
       'email',
       'id',
       'isEmailVerified',
+      'isTwoFactorEnabled',
       'lastLoginAt',
       'lastLoginMethod',
       'phone',
@@ -153,6 +154,13 @@ describe('UserService', () => {
       'role',
     ]);
     expect(options.select).not.toHaveProperty('password');
+    // Named separately from the list above so the reason survives the next
+    // edit: Settings picks "Enable" vs "Disable" from this flag, and while it
+    // was missing the client read undefined as "off" — leaving anyone who
+    // turned 2FA on unable to turn it back off. The secret itself must stay
+    // out; only the boolean is safe to publish.
+    expect(options.select).toHaveProperty('isTwoFactorEnabled', true);
+    expect(options.select).not.toHaveProperty('twoFactorSecret');
     expect(result.id).toBe('user-1');
     expect(redis.set).toHaveBeenCalledWith(
       generateUserKey('detail', 'user-1'),

--- a/apps/user-service/src/users/services/user.service.ts
+++ b/apps/user-service/src/users/services/user.service.ts
@@ -223,6 +223,11 @@ export class UserService implements IUserService, OnModuleInit {
           phone: true,
           profileCompleted: true,
           isEmailVerified: true,
+          // Settings decides between "Enable" and "Disable" from this flag.
+          // Without it the field is undefined on the client, which reads as
+          // "off", so the button stayed on Enable and the disable dialog was
+          // unreachable no matter how many times someone turned 2FA on.
+          isTwoFactorEnabled: true,
           lastLoginAt: true,
           lastLoginMethod: true,
           createdAt: true,


### PR DESCRIPTION
## The symptom

Turn 2FA on, and you can't turn it off. The Settings button stays on **Enable** and reopens the setup dialog.

## The cause

Not the UI — that part is correct. `AccountSection` toggles its label and mode from `currentUser?.isTwoFactorEnabled`, and `TwoFactorDialog` handles `mode="disable"` properly (skips the QR, asks for a code, calls `disable`).

The problem is that **`/user/current-user` never returned that field.** `findOneUserByID` selects an explicit column list, and the flag wasn't on it:

```
current-user returned: id, role, email, phone, profileCompleted,
                       isEmailVerified, lastLoginMethod, lastLoginAt,
                       createdAt, company
```

The client read `undefined` as "off", so the disable path was unreachable regardless of the account's real state.

Reproduced before changing anything: enable 2FA via the API, then `current-user` still reports `isTwoFactorEnabled=undefined`.

Note the **login** response *did* carry it — auth-service builds through the `toUserResponseDTO` allowlist, which includes it. Only user-service's own select was missing it, so the two endpoints disagreed about the same user.

## The fix

One column added to the select.

That select is explicit for a good reason — `password` is a normal column and the DTO is written to Redis *before* serialization, so widening it carelessly would put password hashes in the cache. Only the boolean is added; `twoFactorSecret` stays out, and there's now an assertion for each.

## Why the test didn't catch it

It froze the select's key list as a literal, so it agreed with the bug instead of catching it. It still pins the list, but the flag and the secret are now also asserted **by name with the reason attached**, so the next edit has to make a decision rather than update a literal.

## Verified end to end

Against a local stack (gateway + auth-service + user-service + Postgres + Redis), using real TOTP codes:

```
login                  -> 200  requiresTwoFactor=true
2fa/verify-login       -> 200  logged in ✓
current-user (2FA ON)  -> isTwoFactorEnabled=true   => Settings shows "Disable" ✓
2fa/disable WRONG code -> 401  rejected ✓
2fa/disable REAL code  -> 200  DISABLED ✓
current-user (2FA OFF) -> isTwoFactorEnabled=false  => Settings shows "Enable" ✓
```

Typecheck clean · ESLint clean · **284 tests** pass across user-service and auth-service.

> Cached `current-user` responses written before this will still lack the field until they expire or the user's cache is cleared — `enable`/`disable` already invalidate it via `CLEAR_CURRENT_USER_CACHE`.

Follows #128, which fixed the TOTP check itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)