### PR TITLE
feat(auth): bind the 2FA step to the password step with a signed challenge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,8 @@ JWT_SECRET=replace-with-a-long-random-secret
 JWT_EXPIRES=15m
 JWT_REFRESH_EXPIRES=30d
 JWT_EMAIL_EXPIRES=15m
+# Window to enter a 2FA code after the password step (defaults to 5m)
+JWT_TWO_FACTOR_CHALLENGE_EXPIRES=5m
 
 # ---------------------------------------------------------
 # SESSION

--- a/apps/api-gateway/src/auth/basic/controllers/auth.controller.spec.ts
+++ b/apps/api-gateway/src/auth/basic/controllers/auth.controller.spec.ts
@@ -67,14 +67,14 @@ describe('AuthController', () => {
     request.mockResolvedValue({
       message: 'OTP required',
       requiresTwoFactor: true,
-      userId: 'user-1',
+      twoFactorToken: 'challenge-token',
     });
 
     await expect(
       controller.login({} as any, response, httpRequest),
     ).resolves.toMatchObject({
       requiresTwoFactor: true,
-      userId: 'user-1',
+      twoFactorToken: 'challenge-token',
     });
     expect(setAuthTokenCookies).not.toHaveBeenCalled();
   });

--- a/apps/api-gateway/src/auth/basic/controllers/auth.controller.ts
+++ b/apps/api-gateway/src/auth/basic/controllers/auth.controller.ts
@@ -162,7 +162,7 @@ export class AuthController implements IBasicAuthController {
       return new LoginResponseDTO({
         message: response.message,
         requiresTwoFactor: true,
-        userId: response.userId,
+        twoFactorToken: response.twoFactorToken,
       });
     }
 

--- a/apps/auth-service/src/basic/services/login.service.spec.ts
+++ b/apps/auth-service/src/basic/services/login.service.spec.ts
@@ -10,6 +10,7 @@ describe('LoginService', () => {
   const jwt = {
     generateToken: jest.fn(),
     generateRefreshToken: jest.fn(),
+    generateTwoFactorChallengeToken: jest.fn(async () => 'challenge-token'),
   };
   const cache = { clear: jest.fn() };
   const logger = { error: jest.fn() };
@@ -90,8 +91,14 @@ describe('LoginService', () => {
     await expect(
       service.login({ identifier: 'person@example.com', password: 'valid' }),
     ).resolves.toEqual(
-      expect.objectContaining({ requiresTwoFactor: true, userId: 'u1' }),
+      expect.objectContaining({
+        requiresTwoFactor: true,
+        twoFactorToken: 'challenge-token',
+      }),
     );
+    // The challenge is signed for this user; the raw id is no longer part of
+    // the response, so it cannot be lifted and replayed against verify-login.
+    expect(jwt.generateTwoFactorChallengeToken).toHaveBeenCalledWith('u1');
     expect(jwt.generateToken).not.toHaveBeenCalled();
     expect(repository.save).not.toHaveBeenCalled();
   });

--- a/apps/auth-service/src/basic/services/login.service.ts
+++ b/apps/auth-service/src/basic/services/login.service.ts
@@ -60,12 +60,16 @@ export class LoginService implements ILoginService {
           statusCode: 403,
         });
 
-      // If 2FA is enabled, return a challenge instead of issuing tokens
+      // If 2FA is enabled, return a challenge instead of issuing tokens.
+      // The challenge is signed and short-lived: it is the only thing that
+      // proves to verify-login that this caller cleared the password check.
       if (user.isTwoFactorEnabled) {
         return new LoginResponseDTO({
           message: 'Two-factor authentication required',
           requiresTwoFactor: true,
-          userId: user.id,
+          twoFactorToken: await this.jwtService.generateTwoFactorChallengeToken(
+            user.id,
+          ),
         });
       }
 

--- a/apps/auth-service/src/basic/services/two-factor.service.spec.ts
+++ b/apps/auth-service/src/basic/services/two-factor.service.spec.ts
@@ -17,7 +17,18 @@ import { TwoFactorService } from './two-factor.service';
  */
 describe('TwoFactorService', () => {
   const repository = { findOne: jest.fn(), save: jest.fn() };
-  const jwt = { generateToken: jest.fn(), generateRefreshToken: jest.fn() };
+  const jwt = {
+    generateToken: jest.fn(),
+    generateRefreshToken: jest.fn(),
+    // verify-login no longer trusts a user id from the request; it reads one
+    // out of a signed challenge. The double resolves for a known-good token
+    // and rejects otherwise, mirroring JwtService.
+    verifyTwoFactorChallengeToken: jest.fn(async (token: string) => {
+      if (token !== CHALLENGE) throw new Error('Invalid token type');
+      return 'u1';
+    }),
+  };
+  const CHALLENGE = 'signed-challenge-for-u1';
   const cache = { clear: jest.fn() };
   const logger = { error: jest.fn() };
   const service = new TwoFactorService(
@@ -184,7 +195,10 @@ describe('TwoFactorService', () => {
       repository.findOne.mockResolvedValue(user);
 
       await expectRpcFailure(
-        service.twoFactorVerifyLogin({ userId: 'u1', otp: '000000' }),
+        service.twoFactorVerifyLogin({
+          twoFactorToken: CHALLENGE,
+          otp: '000000',
+        }),
         401,
         'Invalid code. Please try again.',
       );
@@ -200,7 +214,10 @@ describe('TwoFactorService', () => {
       repository.findOne.mockResolvedValue(enabledUser(secret));
 
       await expectRpcFailure(
-        service.twoFactorVerifyLogin({ userId: 'u1', otp: 'abcdef' }),
+        service.twoFactorVerifyLogin({
+          twoFactorToken: CHALLENGE,
+          otp: 'abcdef',
+        }),
         401,
         'Invalid code. Please try again.',
       );
@@ -215,7 +232,7 @@ describe('TwoFactorService', () => {
       jwt.generateRefreshToken.mockResolvedValue('refresh');
 
       const result = await service.twoFactorVerifyLogin({
-        userId: 'u1',
+        twoFactorToken: CHALLENGE,
         otp: token,
       });
 
@@ -225,6 +242,28 @@ describe('TwoFactorService', () => {
       expect(cache.clear).toHaveBeenCalledWith('u1');
     });
 
+    // The point of the challenge: this route is public, and a user id is not
+    // a secret — it comes back in feed, search and matching responses. Only a
+    // signature can show the caller cleared the password step.
+    it('refuses a challenge it did not issue, without touching the account', async () => {
+      const { secret, token } = realCredentials();
+      repository.findOne.mockResolvedValue(enabledUser(secret));
+
+      await expectRpcFailure(
+        service.twoFactorVerifyLogin({
+          twoFactorToken: 'forged-or-expired',
+          otp: token,
+        }),
+        401,
+        'Your sign-in session expired. Please log in again.',
+      );
+
+      // Rejected before the account is even looked up, so a correct code
+      // cannot rescue a challenge that was never issued.
+      expect(repository.findOne).not.toHaveBeenCalled();
+      expect(jwt.generateToken).not.toHaveBeenCalled();
+    });
+
     it('refuses when 2FA is not enabled on the account', async () => {
       repository.findOne.mockResolvedValue({
         id: 'u1',
@@ -232,7 +271,10 @@ describe('TwoFactorService', () => {
         twoFactorSecret: null,
       });
       await expectRpcFailure(
-        service.twoFactorVerifyLogin({ userId: 'u1', otp: '123456' }),
+        service.twoFactorVerifyLogin({
+          twoFactorToken: CHALLENGE,
+          otp: '123456',
+        }),
         400,
         '2FA is not enabled on this account',
       );

--- a/apps/auth-service/src/basic/services/two-factor.service.ts
+++ b/apps/auth-service/src/basic/services/two-factor.service.ts
@@ -145,7 +145,22 @@ export class TwoFactorService implements ITwoFactorService {
     twoFactorVerifyLoginDTO: TwoFactorVerifyLoginDTO,
   ): Promise<TwoFactorVerifyLoginResponseDTO> {
     try {
-      const user = await this.findUserOrThrow(twoFactorVerifyLoginDTO.userId);
+      // Establishes *who* is logging in from a signature rather than from an
+      // id supplied by the caller, so this route can no longer be driven with
+      // a user id lifted out of any ordinary API response.
+      let userId: string;
+      try {
+        userId = await this.jwtService.verifyTwoFactorChallengeToken(
+          twoFactorVerifyLoginDTO.twoFactorToken,
+        );
+      } catch {
+        throw new RpcException({
+          message: 'Your sign-in session expired. Please log in again.',
+          statusCode: 401,
+        });
+      }
+
+      const user = await this.findUserOrThrow(userId);
 
       if (!user.isTwoFactorEnabled || !user.twoFactorSecret) {
         throw new RpcException({

--- a/libs/common/src/config/configuration.ts
+++ b/libs/common/src/config/configuration.ts
@@ -61,6 +61,12 @@ export default () => ({
     expiresIn: process.env.JWT_EXPIRES,
     refreshExpiresIn: process.env.JWT_REFRESH_EXPIRES,
     emailExpiresIn: process.env.JWT_EMAIL_EXPIRES,
+    // The window between passing the password check and entering a code.
+    // Long enough to fetch a phone, short enough that a leaked challenge is
+    // worthless by the time anyone could use it. Defaulted rather than
+    // required so an unset env cannot silently mint a non-expiring token.
+    twoFactorChallengeExpiresIn:
+      process.env.JWT_TWO_FACTOR_CHALLENGE_EXPIRES ?? '5m',
   },
 
   session: {

--- a/libs/common/src/jwt/jwt.service.ts
+++ b/libs/common/src/jwt/jwt.service.ts
@@ -30,6 +30,45 @@ export class JwtService {
     return refreshToken;
   }
 
+  /**
+   * Short-lived proof that a password login just succeeded for this user.
+   *
+   * The 2FA step used to take a bare `userId` from the request body, which
+   * meant `verify-login` had no way to tell a caller who had just passed the
+   * password check from one who had simply read an id out of a feed response.
+   * The signature is what ties the two halves of the login together.
+   *
+   * Deliberately not an access token: it carries no role, cannot be used on
+   * any authenticated route, and dies in minutes rather than hours.
+   */
+  async generateTwoFactorChallengeToken(userId: string): Promise<string> {
+    return this.jwtService.signAsync(
+      { id: userId, type: 'two-factor-challenge' },
+      {
+        expiresIn: this.configService.get<StringValue>(
+          'jwt.twoFactorChallengeExpiresIn',
+        ),
+      },
+    );
+  }
+
+  /** Returns the user id the challenge was issued for, or throws. */
+  async verifyTwoFactorChallengeToken(token: string): Promise<string> {
+    try {
+      const decoded = await this.jwtService.verifyAsync(token);
+      if (decoded.type !== 'two-factor-challenge')
+        throw new Error('Invalid token type');
+      if (typeof decoded.id !== 'string' || !decoded.id)
+        throw new Error('Invalid token payload');
+      return decoded.id;
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+  }
+
   async verifyToken(token: string): Promise<any> {
     try {
       const decoded = await this.jwtService.verifyAsync(token);

--- a/libs/contracts/src/dtos/auth/login.dto.ts
+++ b/libs/contracts/src/dtos/auth/login.dto.ts
@@ -21,7 +21,13 @@ export class LoginResponseDTO extends CoreResponseDTO {
   refreshToken?: string | null;
   user?: UserResponseDTO;
   requiresTwoFactor?: boolean;
-  userId?: string;
+  /**
+   * Short-lived signed proof that the password step just succeeded. Replaces
+   * the bare `userId` this used to return: an id is public — it comes back in
+   * feed, search and matching responses — so it proved nothing about who was
+   * asking. The signature is what binds the two halves of the login.
+   */
+  twoFactorToken?: string;
 
   constructor(partial: Partial<LoginResponseDTO>) {
     super(partial);

--- a/libs/contracts/src/dtos/auth/two-factor.dto.ts
+++ b/libs/contracts/src/dtos/auth/two-factor.dto.ts
@@ -1,4 +1,10 @@
-import { IsNotEmpty, IsNumberString, IsUUID, Length } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsNumberString,
+  IsString,
+  IsUUID,
+  Length,
+} from 'class-validator';
 import { CoreResponseDTO } from '../shared/core-response.dto';
 import { UserResponseDTO } from '../shared/user.dto';
 
@@ -50,9 +56,9 @@ export class TwoFactorDisableResponseDTO extends CoreResponseDTO {
 }
 
 export class TwoFactorVerifyLoginDTO {
-  @IsUUID()
+  @IsString()
   @IsNotEmpty()
-  userId: string;
+  twoFactorToken: string;
 
   @IsNumberString({ no_symbols: true })
   @Length(6, 6)


### PR DESCRIPTION
> ⚠️ **Ships with ApsaraTalent-Web#feat/two-factor-challenge-token.** This changes the `verify-login` request contract, so a browser on the old web build would send the wrong field. Merge and release the two together.

## The gap

`POST /auth/2fa/verify-login` is public — it has to be, it runs before tokens exist — and it took `{ userId, otp }` straight from the request body. Nothing in it established that the caller had passed the password step.

And a user id is not a secret: `id` is on the allowlist in `to-user-response.util.ts`, so feed, search and matching all return them.

With the code check now correct (#128) an attacker would still need a valid TOTP, so this wasn't directly exploitable — but the two halves of the login were never actually joined.

## The change

Login answers a 2FA-enabled account with a short-lived **signed challenge** instead of the raw id, and `verify-login` reads the user out of that signature:

```
claims: type=two-factor-challenge   ttl=300s   carriesRole=false
```

Deliberately not an access token — it carries no role, works on no other route, and expires in five minutes. `JWT_TWO_FACTOR_CHALLENGE_EXPIRES` is **defaulted in `configuration.ts`** rather than required, so an unset env can't silently mint a long-lived one.

The challenge is verified **before the account is loaded**, so a correct code can't rescue a challenge that was never issued.

**Unchanged:** `setup`, `enable` and `disable` still take the id from the session. Those are `AuthGuard`-protected and were never the weak part.

## Verified end to end

Against a local stack with real TOTP codes:

```
login (2FA on)       -> 200  twoFactorToken=issued ✓  userId leaked=no ✓
verify-login FORGED  -> 401  authCookies=0  rejected ✓
verify-login GENUINE -> 200  logged in, 2 auth cookies ✓
```

New test asserts a forged challenge is refused *and* that `repository.findOne` is never reached.

**147 suites / 1316 tests pass** · typecheck clean · ESLint clean.

Completes the 2FA work alongside #128 (TOTP result read correctly) and #129 (disable reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)